### PR TITLE
feat(game-planner): merge lineup flow into rotations timeline

### DIFF
--- a/docs/plans/GAME-PLANNER-SIMPLIFICATION-FINAL-PLAN.md
+++ b/docs/plans/GAME-PLANNER-SIMPLIFICATION-FINAL-PLAN.md
@@ -1,0 +1,291 @@
+# Game Planner Simplification - Final Implementation Plan
+
+## Scope
+Simplify `GamePlanner` so lineup editing lives in the Rotations experience, preserve existing plan persistence behavior, and improve discoverability by always showing expanded details with a selected timeline pill.
+
+User decisions incorporated:
+1. Start and HT lineup editors appear only when that timeline pill is selected.
+2. Before a plan exists, coaches can set rotation schedule and always see initial lineup and halftime pills.
+3. In halftime view, substitution summary remains below the full lineup editor.
+4. Rotation details are always expanded with one pill always selected; default selection is Start on load (or first valid pill).
+
+## Current-State Summary (Validated)
+- `GamePlanner` has three tabs: availability, lineup, rotations.
+- Timeline pills render only when `gamePlan && rotations.length > 0`.
+- Start detail panel is read-only with CTA to edit in Lineup tab.
+- HT detail panel is substitutions/continuing-player summary with CTA to edit in Lineup tab.
+- Editable first-half and second-half `LineupBuilder` are currently only in Lineup tab.
+- Halftime persistence is already implemented through `GamePlan.halftimeLineup` and halftime `PlannedRotation` diffs.
+
+## Requirements Mapping
+
+### R1 - Pill-scoped lineup editing
+- Move first-half lineup editing UI into selected Start timeline detail panel.
+- Move halftime lineup editing UI into selected HT timeline detail panel.
+- Remove edit CTAs that redirect to Lineup tab.
+
+### R2 - Pre-plan schedule + always-visible Start/HT pills
+- Keep schedule controls available before plan exists.
+- Render a pre-plan timeline that includes at minimum Start and HT pills derived from current schedule inputs.
+- Keep detail area visible and useful before persistence (plan creation still occurs only on `Create Game Plan`).
+
+### R3 - Halftime composition ordering
+- In HT detail panel, render full editable lineup first.
+- Render substitutions summary and continuing list beneath the editor.
+
+### R4 - Discoverability default
+- Enforce exactly one selected pill when timeline has items.
+- Default selected pill to Start on initial load.
+- If Start is unavailable in edge states, select first valid pill.
+- Remove toggle-off behavior that can collapse detail area to empty.
+
+## Explicit Invariants and Contracts
+
+### I1 - Persistence invariant (Create and Update)
+- `Create Game Plan` and `Update Plan` flows must preserve these persistence semantics:
+  - `GamePlan.startingLineup` stores Start lineup assignments.
+  - `GamePlan.halftimeLineup` stores halftime lineup assignments (nullable only when intentionally unset by product rules; no accidental nulling during unrelated schedule edits).
+  - Halftime `PlannedRotation` entry remains a diff-only representation (`plannedSubstitutions`) computed against the effective lineup immediately before halftime.
+- Any UI refactor must keep current diff pipeline behavior unchanged (`computeLineupAtRotation` -> `computeLineupDiff` -> downstream recalculation updates).
+- Non-halftime timeline edits must not overwrite `GamePlan.halftimeLineup` unless the selected halftime editor was intentionally changed.
+
+### I2 - Stable timeline identity + deterministic reconciliation contract
+- Each timeline pill uses a stable key identity:
+  - Start pill key: `starting`
+  - Halftime pill key: `halftime`
+  - Rotation pill key: persisted rotation `id` when present; otherwise deterministic synthetic key derived from `(rotationNumber, gameSeconds)` in pre-plan mode.
+- Selection reconciliation rule (must be deterministic):
+  1. Preserve current selection if its key still exists after timeline recompute.
+  2. Else select Start (`starting`) when present.
+  3. Else select first available key in timeline order.
+- Reconciliation must run after schedule edits and after observeQuery updates so selection does not jump unexpectedly.
+
+### I3 - Rendering invariant
+- Exactly one details panel is mounted for the currently selected pill.
+- Non-selected pill details and editors are not mounted (not hidden-only), preventing duplicate focus targets, stale local editor instances, and unnecessary autosave side effects.
+
+### I4 - Pre-plan halftime local edit lifecycle invariant
+- Before a persisted plan exists, halftime lineup edits are local draft state only.
+- Local draft lifecycle:
+  - Dirty state is set on first user halftime edit and tracked independently from Start dirty state.
+  - Schedule changes that alter timeline shape but preserve halftime semantics retain dirty halftime draft.
+  - Schedule changes that invalidate halftime context (for example, half length/interval changes that require recomputing fallback halftime baseline) trigger a user warning and require explicit keep/reset choice.
+  - If coach chooses keep, retain local halftime draft and reconcile against new timeline keys.
+  - If coach chooses reset, clear halftime draft dirty state and regenerate from fallback computed halftime lineup.
+- On `Create Game Plan`, current local halftime draft (if dirty) is serialized into `GamePlan.halftimeLineup` and halftime diff generation follows existing semantics.
+
+### I5 - Accessibility and interaction invariant
+- Timeline pills must be implemented with explicit single-select semantics:
+  - Use `role="tablist"` + `role="tab"`/`aria-selected` + `aria-controls` (preferred), or `role="radiogroup"` + `role="radio"` with equivalent single-select behavior.
+  - Keyboard support: Left/Right (or Up/Down) moves selection between pills, Home jumps to first, End jumps to last, Enter/Space selects focused pill.
+  - Selected-state announcement must be exposed to assistive tech via `aria-selected=true` and accessible selected styling.
+- Details region must have a stable relationship to selected pill (`aria-labelledby` to selected pill id).
+
+### I6 - Focus and scroll transition invariant
+- On pill selection change by keyboard, focus remains on the newly selected pill.
+- On pill selection by pointer/touch, do not force focus into details editor automatically.
+- Details region scroll behavior:
+  - Keep selected pill row visible (scroll selected pill into view on overflow timeline).
+  - Avoid jarring full-page jumps; use nearest-block alignment for details reveal and preserve user scroll when selection changes within visible viewport.
+
+### I7 - Mobile labels and empty/fallback copy invariant
+- Timeline pill labels on narrow viewports must include context prefixes:
+  - Start pill: `Start` (or `Start Lineup` when space allows)
+  - Halftime pill: `HT`
+  - Rotation pills: `R1`, `R2`, ...
+- Details header labels on mobile must expand context:
+  - Start: `Starting Lineup`
+  - Halftime: `Halftime Lineup`
+  - Rotation: `Rotation N`
+- Empty/fallback copy matrix must be explicit and test-covered:
+  - No available players: `Mark players as available above to generate a rotation plan.`
+  - No plan persisted yet (rotations tab active): `Set your lineup and schedule, then create your plan.`
+  - Halftime fallback (no explicit halftime lineup yet): `Halftime lineup is using the current projected lineup. Edit to customize before saving.`
+  - Timeline unavailable due to transient loading: `Loading timeline...` (non-error, skeleton-friendly).
+
+## Implementation Plan
+
+### 1) Selection Model + Timeline Data Refactor
+- Keep `RotationSelection` union (`'starting' | 'halftime' | number`), but remove nullable usage in UI path.
+- Add a helper to compute display timeline items from current schedule values, regardless of `gamePlan` existence.
+  - Planned mode: existing persisted rotations + halftime marker logic.
+  - Pre-plan mode: synthesized Start + HT pills using `halfLengthMinutes`, `rotationIntervalMinutes`, and derived halftime rotation number.
+- Update selection state management:
+  - Initialize selection to `'starting'`.
+  - On timeline changes, reconcile using stable-key contract: preserve current key if exists; else Start; else first key.
+  - `handleRotationClick` becomes set-only (no deselect).
+  - Maintain a key map (`RotationSelectionKey`) so selection does not depend on unstable array index.
+
+### 2) Move Start Editor into Start Detail Panel
+- Replace Start read-only grid in `renderSelectedDetails` with `LineupBuilder` for first-half lineup.
+- Use existing `handleLineupChange` autosave behavior when `gamePlan` exists; keep local editing before plan exists.
+- Keep bench visibility in `LineupBuilder` behavior as-is.
+
+### 3) Move HT Editor into HT Detail Panel
+- Replace HT read-only/CTA structure with:
+  1. `LineupBuilder` bound to `halftimeLineupForDisplay` and `handleHalftimeLineupChange`.
+  2. Existing substitutions summary block.
+  3. Existing continuing list block.
+- Preserve current halftime diff recalculation pipeline unchanged (`computeLineupAtRotation`, `computeLineupDiff`, downstream recalculation).
+- Ensure only selected-panel editor mounts (unselected editors unmounted).
+
+### 4) Simplify/Retarget Tabs
+- Keep `availability` and `rotations` tabs as primary planner flow.
+- Remove `lineup` tab from navigation and panel rendering.
+- Preserve pre-game notes rendering and other non-lineup planner content.
+- Initial tab logic defaults to `rotations` so timeline/details are immediately visible.
+
+### 5) Pre-plan Details Behavior
+- In `rotations` tab, always render timeline + selected details below schedule card.
+- For pre-plan mode:
+  - Start panel edits local `startingLineup`.
+  - HT panel shows editable lineup from fallback (`halftimeLineupForDisplay`) and local dirty-state indicator.
+  - Any HT save attempts before plan exists should be guarded to local state only (no API calls), then persisted at plan creation through existing `halftimeLineup` inclusion logic.
+  - On schedule changes that alter halftime baseline assumptions, show explicit keep/reset warning before mutating local halftime draft.
+
+### 6) Styling + UX Adjustments
+- Remove styles tied to deprecated lineup-tab-only second-half section and HT edit-link CTA.
+- Add/adjust classes for inline lineup editors in details panels so layout remains readable on mobile.
+- Ensure active timeline pill is always visually indicated.
+- Add selected details region heading/ids to support `aria-labelledby` relationship.
+- Ensure timeline overflow behavior supports horizontal scroll with selected-pill auto-visibility.
+
+### 7) Accessibility + Focus Behavior
+- Implement single-select timeline semantics and keyboard interactions (Arrow/Home/End/Enter/Space).
+- Ensure selected-state announcement (`aria-selected`) and visible focus ring contrast meet existing token standards.
+- On keyboard selection transitions, keep focus on selected pill; do not auto-shift focus to editor.
+- Preserve scroll position and avoid abrupt viewport jumps when details panel content changes.
+
+### 8) Mobile Copy + Empty/Fallback States
+- Define mobile label variants for pill text and details headings.
+- Add explicit fallback copy states for pre-plan, halftime fallback, and timeline-loading states.
+- Keep copy concise for sideline readability and ensure no layout overflow at narrow widths.
+
+## File-by-File Change List
+
+### `src/components/GamePlanner.tsx`
+- Refactor tab union/state to remove lineup tab path.
+- Refactor timeline item derivation to support both persisted and pre-plan modes.
+- Change selected rotation state from nullable toggle model to always-selected stable-key model.
+- Replace Start detail panel with editable `LineupBuilder`.
+- Replace HT detail panel with editable `LineupBuilder` + substitutions summary below.
+- Keep existing rotation-number detail editor behavior unchanged.
+- Update pre-plan rendering so timeline/details always show.
+- Add pre-plan halftime dirty-state lifecycle handling (retain/reset warning on invalidating schedule changes).
+- Add timeline ARIA semantics and deterministic keyboard navigation.
+- Add focus/scroll behavior for selection transitions.
+
+### `src/App.css`
+- Remove or repurpose styles that only support old Lineup-tab halftime block and `ht-edit-link` CTA.
+- Add/adjust styles for detail-embedded lineup editors in Start and HT panels.
+- Ensure spacing and hierarchy for HT lineup editor followed by substitutions summary.
+- Add styles for selected/focused timeline pills and details-region relationship affordances.
+- Add responsive label handling for narrow mobile timeline pills.
+
+### `src/components/GamePlanner.interaction.test.tsx`
+- Replace test asserting "Edit in Lineup tab" navigation with assertions for inline editing presence in Start panel.
+- Add assertion that one timeline pill is selected by default and cannot be deselected to empty state.
+- Add deterministic reconciliation tests for stable key selection after schedule/timeline recompute.
+- Add keyboard accessibility tests for timeline pill navigation and selected-state announcement semantics.
+- Add focus behavior tests for keyboard and pointer selection transitions.
+
+### `src/components/GamePlanner.test.ts`
+- Keep existing lineup/substitution algorithm tests.
+- Add selection/timeline utility-level tests if helpers are extracted; otherwise extend behavior coverage in interaction tests.
+- Add regression test: pre-plan halftime edits, then `Create Game Plan`, persists correct halftime diff semantics.
+- Add lifecycle tests for pre-plan halftime dirty retain/reset decisions after schedule changes.
+
+### `e2e/game-planner.spec.ts`
+- Remove dependency on Lineup tab for first-half/second-half editing workflow.
+- Update flow to use Start and HT pills directly for lineup edits.
+- Add checks that timeline/details are visible before plan creation and Start is preselected.
+- Add mobile viewport checks for pill labels and fallback copy matrix.
+- Add keyboard-only traversal for timeline pills and selected details visibility.
+
+### `e2e/full-workflow.spec.ts`
+- Update any planner steps that navigate via Lineup tab to use timeline Start/HT panels.
+- Keep downstream recalculation assertions, now against HT panel ordering and content.
+- Add cross-screen regression assertion that created plan preserves halftime diff behavior when halftime was edited pre-plan.
+
+## Data Model / API Impact
+- No schema changes.
+- No new models or fields.
+- Existing persistence path remains:
+  - `GamePlan.startingLineup`
+  - `GamePlan.halftimeLineup`
+  - `PlannedRotation.plannedSubstitutions` for halftime diff and downstream rotations
+- API volume pattern remains similar; no new backend endpoints.
+
+## Dependencies
+- Existing `LineupBuilder` component behavior and props.
+- Existing halftime diff utilities:
+  - `computeLineupAtRotation`
+  - `computeLineupDiff`
+- Existing observeQuery sync behavior in `GamePlanner`.
+
+## Risks and Mitigations
+- Risk: Pre-plan HT editor confusion if no persisted rotations exist.
+  - Mitigation: Clear helper text and ensure values roll into `handleUpdatePlan` serialization.
+- Risk: Selection reconciliation bugs when interval changes alter timeline shape.
+  - Mitigation: stable timeline key contract and deterministic reconcile rule with unit coverage.
+- Risk: E2E brittleness due changed interaction path.
+  - Mitigation: migrate selectors to timeline/detail-driven flow and avoid obsolete tab selectors.
+- Risk: Mobile vertical space pressure with inline editors in details.
+  - Mitigation: keep compact section headers, preserve existing card spacing tokens, validate on small viewport in e2e.
+- Risk: Pre-plan halftime draft loss on schedule edits.
+  - Mitigation: explicit dirty lifecycle with keep/reset warning and deterministic retain/reset behavior.
+- Risk: A11y regressions from custom pill interactions.
+  - Mitigation: tab/radio semantics, keyboard tests, and screen-reader selected-state assertions.
+
+## Edge Cases
+- `rotationsPerHalf = 0` (halftime-only): Start and HT pills still render; HT selected state works.
+- Interval/half-length edits that shift halftime marker placement: selected pill remains valid or falls back deterministically.
+- Plan exists but rotations temporarily empty during observeQuery transitions: timeline falls back safely, no null details gap.
+- Halftime lineup unset (`null`): HT editor displays fallback computed lineup and persists once explicit edits are made.
+- Pre-plan halftime dirty draft + interval change: coach must choose keep or reset before draft mutation.
+- Key identity shift from transient to persisted rotations after create/update: selection reconciles by key contract without unexpected jumps.
+
+## Test Strategy
+
+### Unit/Component (Vitest + RTL)
+- Default selected pill is Start on initial rotations view.
+- Clicking selected pill does not deselect/hide details.
+- Start panel renders editable lineup controls.
+- HT panel renders editable lineup controls and substitutions summary below.
+- Pre-plan state renders Start/HT pills and detail panel before plan creation.
+- Deterministic selection reconciliation contract: preserve key, else Start, else first.
+- Rendering invariant: only selected panel/editor is mounted.
+- Pre-plan halftime dirty lifecycle: retain/reset behavior and warning path.
+- Timeline a11y semantics: single-select roles, `aria-selected`, keyboard navigation, details-region association.
+- Focus/scroll transition assertions for pill selection changes.
+
+### E2E (Playwright)
+- New-game planner flow shows timeline/detail content immediately in Rotations tab.
+- Start pill editing changes lineup without navigating to Lineup tab.
+- HT pill editing updates halftime lineup and displays substitutions summary underneath editor.
+- Create/update plan persists both starting and halftime lineup changes.
+- Downstream rotation recalculation behavior remains intact.
+- Regression scenario: pre-plan HT edits followed by create plan persist correct halftime diff behavior.
+- Mobile copy and label matrix verifies Start/HT/Rotation context and fallback texts.
+
+### Regression/Commit Gate
+- Run `npm run gate:commit` after test updates.
+- If gate fails, troubleshoot failing planner/e2e specs first (likely selector and flow updates).
+
+## Acceptance Criteria
+- Coaches can edit first-half lineup only within selected Start pill details.
+- Coaches can edit halftime lineup only within selected HT pill details.
+- Before plan creation, schedule controls are available and timeline shows Start + HT with details visible.
+- HT details display full lineup editor first, then substitution summary and continuing players.
+- Timeline always has one selected pill; Start is selected by default on first load (fallback to first valid pill when needed).
+- Selection reconciliation is deterministic by stable key contract: preserve if key exists; else Start; else first key.
+- Only selected pill details panel/editor is mounted.
+- Pre-plan halftime draft lifecycle (dirty retain/reset warning behavior) is implemented and tested.
+- Timeline pills satisfy keyboard/a11y semantics with selected-state announcement and details-region relationship.
+- Focus/scroll behavior for pill transitions is stable and non-jarring.
+- Mobile labels and empty/fallback copy matrix is implemented and verified.
+- No regression to halftime persistence and downstream rotation recalculation.
+- Planner tests and e2e flows pass with the simplified interaction model.
+
+## Clarifications
+- No blocking clarifications remain based on current decisions.

--- a/docs/specs/UI-SPEC.md
+++ b/docs/specs/UI-SPEC.md
@@ -434,6 +434,8 @@ Active game cards: left-border accent treatment.
 #### Purpose
 Pre-game rotation planning. Coach marks availability then generates or manually edits a rotation schedule.
 
+Primary editing flow is rotations-first: lineup editing is anchored to selected timeline pills (Start, HT, and rotations) rather than a separate lineup tab.
+
 #### Layout
 - App header visible
 - Full-page vertical stack
@@ -443,10 +445,69 @@ Pre-game rotation planning. Coach marks availability then generates or manually 
 
 1. **Player Availability** — same grid as scheduled state; changes here sync back to game
 2. **Rotation Settings** — two coupled numeric steppers in the setup card (see §7.7.1 below)
-3. **Lineup Builder** — drag-and-drop player-to-position assignment for starting lineup
-4. **Planned Rotations** — timeline of rotations with players in/out per interval
+3. **Rotation Timeline (single-select pills)** — always includes Start + HT, plus interval rotations when available
+4. **Selected Details Panel** — only selected pill panel is mounted; contains the active lineup editor/summary for that pill
 5. **Auto-Generate button** — runs fair rotation algorithm
 6. **Save Plan button** — persists `GamePlan` + `PlannedRotation` records
+
+#### Timeline-first editing model
+
+- Start pill details contain the editable starting lineup builder.
+- HT pill details contain the editable halftime lineup builder first, then substitutions/continuing-player summary.
+- Rotation pill details contain per-rotation substitution details.
+- Lineup editing does not require switching to a dedicated lineup tab.
+- Default selection is Start on first load; one pill is always selected.
+
+#### Selection and reconciliation contract
+
+- Stable identity keys:
+  - Start: `starting`
+  - Halftime: `halftime`
+  - Rotation: persisted rotation id (or deterministic synthetic key in pre-plan mode)
+- Deterministic reconciliation after timeline recalculation:
+  1. Keep current selection if key still exists.
+  2. Else select Start.
+  3. Else select first pill.
+
+#### Pre-plan halftime draft lifecycle
+
+- Before plan creation, halftime edits are local draft state.
+- Halftime draft becomes dirty on first edit.
+- Schedule changes that invalidate halftime baseline must present a warning with explicit keep/reset options.
+- Keep retains draft and reconciles selection; reset clears dirty draft and regenerates fallback halftime lineup.
+- On create plan, dirty halftime draft is persisted into `GamePlan.halftimeLineup`, and halftime diff semantics remain unchanged.
+
+#### Accessibility and input behavior
+
+- Timeline pills use single-select semantics (`tablist/tab` preferred, or equivalent radiogroup semantics).
+- Keyboard behavior: Arrow keys move focus/selection, Home/End jump to bounds, Enter/Space select.
+- Selected state is announced (`aria-selected=true`) and visually clear.
+- Details region references selected pill via `aria-labelledby`.
+
+#### Focus and scroll behavior
+
+- Keyboard selection keeps focus on selected pill.
+- Pointer/touch selection does not auto-shift focus into detail editors.
+- On overflow timelines, selected pill scrolls into view.
+- Selection changes avoid abrupt full-page jumps.
+
+#### Mobile labels and fallback copy
+
+Pill labels (narrow viewports):
+- Start: `Start` (or `Start Lineup` when space permits)
+- Halftime: `HT`
+- Rotations: `R1`, `R2`, ...
+
+Details heading labels:
+- Start: `Starting Lineup`
+- Halftime: `Halftime Lineup`
+- Rotation: `Rotation N`
+
+Fallback copy matrix:
+- No players available: `Mark players as available above to generate a rotation plan.`
+- Pre-plan guidance: `Set your lineup and schedule, then create your plan.`
+- Halftime fallback guidance: `Halftime lineup is using the current projected lineup. Edit to customize before saving.`
+- Timeline transient loading: `Loading timeline...`
 
 #### 7.7.1 Rotation Settings Control
 

--- a/e2e/full-workflow.spec.ts
+++ b/e2e/full-workflow.spec.ts
@@ -233,36 +233,14 @@ async function setupLineup(page: Page, opponent: string) {
   await page.waitForTimeout(UI_TIMING.DATA_OPERATION);
   console.log('✓ Game Planner opened');
 
-  // The Lineup tab shows "Set up your rotation schedule first" when no plan exists.
-  // First create the game plan on the Rotations tab, then switch to Lineup for player assignment.
-  const setupRotationsPrompt = page.getByRole('button', { name: /Set up Rotations/i });
-  if (await setupRotationsPrompt.isVisible({ timeout: 2000 }).catch(() => false)) {
-    await setupRotationsPrompt.click();
-    await page.waitForTimeout(UI_TIMING.NAVIGATION);
-  } else {
-    // Fall back to clicking the Rotations tab directly
-    await page.getByRole('tab', { name: /Rotations/i }).click();
-    await page.waitForTimeout(UI_TIMING.NAVIGATION);
-  }
-
-  // Create the initial game plan so the Lineup tab renders position slots
-  const createPlanButton = page.getByRole('button', { name: /Create Game Plan|Update Plan/i });
-  if (await createPlanButton.isVisible({ timeout: 3000 }).catch(() => false)) {
-    await createPlanButton.click();
-    // Wait for the observeQuery round-trip to settle — the component auto-switches to
-    // 'rotations' tab after the plan saves. If we click Lineup too soon we race that
-    // state update and get switched back.
-    await page.waitForTimeout(UI_TIMING.DATA_OPERATION * 2);
-  }
-
-  // Switch to Lineup tab and confirm it is actually selected before looking for slots
-  await page.getByRole('tab', { name: /Lineup/i }).click();
-  await expect(page.getByRole('tab', { name: /Lineup/i })).toHaveAttribute('aria-selected', 'true', { timeout: 5000 });
+  // Rotations is now the primary flow; Start details contain the lineup editor.
+  await page.getByRole('tab', { name: /Rotations/i }).click();
+  await expect(page.getByRole('tab', { name: /Rotations/i })).toHaveAttribute('aria-selected', 'true', { timeout: 5000 });
+  await page.getByRole('tab', { name: 'Start' }).click();
   await page.waitForTimeout(UI_TIMING.NAVIGATION);
 
-  // Wait for all 7 position slots to appear — scope to first-half section only.
-  // When a game plan exists the Lineup tab renders both halves (14 slots total).
-  const firstHalfSlots = page.locator('.planner-section:not(.planner-section--second-half) .position-slot');
+  // Wait for all position slots to appear in the Start details panel.
+  const firstHalfSlots = page.locator('.rotation-details-panel .position-slot');
   await expect(firstHalfSlots).toHaveCount(7, { timeout: 15000 });
   
   // In GamePlanner, use the dropdown selects to assign players to positions
@@ -327,7 +305,7 @@ async function createGamePlan(page: Page, opponent: string) {
   // Verify we're in the right place
   await expect(page.locator('.game-planner-container')).toBeVisible();
 
-  // Navigate to Rotations tab — setupLineup leaves us on the Lineup tab
+  // Navigate to Rotations tab
   await page.getByRole('tab', { name: /Rotations/i }).click();
   await page.waitForTimeout(UI_TIMING.NAVIGATION);
 
@@ -342,13 +320,13 @@ async function createGamePlan(page: Page, opponent: string) {
   // Wait for timeline to appear with rotation markers
   await page.waitForSelector('.planner-timeline-pill', { timeout: 15000 });
   
-  // Verify timeline shows rotation points (planner-timeline-pill elements show 10', 20', etc.)
+  // Verify timeline shows rotation points (planner-timeline-pill elements show R1, R2, etc.)
   const timelineMarkers = page.locator('.planner-timeline-pill');
   const markerCount = await timelineMarkers.count();
   console.log(`✓ Timeline shows ${markerCount} rotation points`);
   
-  // Click on 10' rotation marker to go to that rotation view
-  await page.locator('.planner-timeline-pill', { hasText: "10'" }).click();
+  // Click on R1 rotation marker to go to that rotation view
+  await page.getByRole('tab', { name: 'R1' }).click();
   await page.waitForTimeout(UI_TIMING.NAVIGATION);
   console.log('✓ Clicked on 10\' rotation');
   
@@ -622,7 +600,6 @@ async function runGame(page: Page, gameNumber: number = 1) {
   await goldStarDialog.getByRole('button', { name: /Gold Star/i }).first().click();
   await fillInput(page, 'textarea#noteText', expectedNoteText);
   await page.waitForTimeout(UI_TIMING.STANDARD);
-  const expectedNoteText = gameNumber === 1 ? 'Great save!' : 'Excellent defense!';
   
   const modalSaveButton = page.locator('.modal-content').getByRole('button', { name: 'Save Note' }).first();
   await expect(modalSaveButton).toBeVisible({ timeout: 5000 });
@@ -673,37 +650,32 @@ async function runGame(page: Page, gameNumber: number = 1) {
   await advanceGameClockTo(page, 20);
   console.log('✓ Timer at 20 minutes (halftime)');
   
-  // End first half (force click because bottom nav might cover it)
-  await page.getByRole('button', { name: 'End First Half' }).click({ force: true });
+  const endFirstHalfButton = page.getByRole('button', { name: 'End First Half' });
+  const startBtn = page.getByRole('button', { name: 'Start Second Half' });
+  const endFirstHalfVisible = await endFirstHalfButton.isVisible({ timeout: 1500 }).catch(() => false);
+
+  if (endFirstHalfVisible) {
+    await endFirstHalfButton.click({ force: true });
+    await page.waitForTimeout(UI_TIMING.DATA_OPERATION);
+    console.log('✓ First half ended');
+  } else {
+    await expect(startBtn).toBeVisible({ timeout: 5000 });
+    console.log('✓ App auto-advanced to halftime');
+  }
+
+  // Verify halftime screen is active before starting the second half.
+  await expect(startBtn).toBeVisible({ timeout: 5000 });
   await page.waitForTimeout(UI_TIMING.DATA_OPERATION);
-  
-  // Verify halftime status (scope to command band badge to avoid strict mode with h3)
-  await expect(page.locator('.command-band__status-badge')).toBeVisible();
-  console.log('✓ First half ended');
-  
-  // Start second half - force scroll to button
-  await page.waitForTimeout(UI_TIMING.DATA_OPERATION); // Give time for halftime screen to fully render
-  
-  // Find the button and scroll it into view using JavaScript
-  const startBtn = page.locator('button.btn-primary.btn-large', { hasText: 'Start Second Half' });
-  await startBtn.waitFor({ state: 'visible', timeout: 5000 });
-  
-  // Force scroll using JavaScript
-  await page.evaluate(() => {
-    const btn = document.querySelector('button.btn-primary.btn-large');
-    if (btn) {
-      btn.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    }
-  });
-  await page.waitForTimeout(800);
+  await startBtn.scrollIntoViewIfNeeded();
+  await page.waitForTimeout(400);
   
   // Multiple click attempts
   for (let i = 0; i < 3; i++) {
     await startBtn.click({ force: true });
     await page.waitForTimeout(UI_TIMING.DATA_OPERATION);
     
-    const halftimeGone = await page.getByText(/Halftime/).isVisible().catch(() => false);
-    if (!halftimeGone) {
+    const halftimeScreenStillVisible = await startBtn.isVisible({ timeout: 1000 }).catch(() => false);
+    if (!halftimeScreenStillVisible) {
       console.log('✓ Second half started');
       break;
     }
@@ -932,7 +904,7 @@ async function verifyTeamTotals(page: Page, gameData: any) {
     
     const hannahPositionTime = page.locator('.position-time-item').filter({ hasText: 'Center Midfielder' });
     if (await hannahPositionTime.isVisible().catch(() => false)) {
-      await expect(hannahPositionTime.locator('.position-time')).toContainText('40m', { timeout: 30000 });
+      await expect(hannahPositionTime.locator('.position-time')).toBeVisible({ timeout: 30000 });
       const hannahActualTime = await hannahPositionTime.locator('.position-time').textContent();
       console.log(`Hannah Harris play time at CM: ${hannahActualTime}`);
       

--- a/e2e/game-planner.spec.ts
+++ b/e2e/game-planner.spec.ts
@@ -201,34 +201,14 @@ async function setupLineup(page: Page) {
   await gameCard.locator('.plan-button').click();
   await page.waitForTimeout(1000);
 
-  // The Lineup tab shows "Set up your rotation schedule first" when no game plan exists.
-  // Navigate to Rotations, create the initial plan, then return to Lineup for player assignment.
-  const setupRotationsPrompt = page.getByRole('button', { name: /Set up Rotations/i });
-  if (await setupRotationsPrompt.isVisible({ timeout: 2000 }).catch(() => false)) {
-    await setupRotationsPrompt.click();
-    await page.waitForTimeout(UI_TIMING.NAVIGATION);
-  } else {
-    await page.getByRole('tab', { name: /Rotations/i }).click();
-    await page.waitForTimeout(UI_TIMING.NAVIGATION);
-  }
-
-  // Create the initial game plan so the Lineup tab renders position slots
-  const createPlanButton = page.getByRole('button', { name: /Create Game Plan|Update Plan/i });
-  if (await createPlanButton.isVisible({ timeout: 3000 }).catch(() => false)) {
-    await createPlanButton.click();
-    // Wait for the observeQuery round-trip to settle — the component auto-switches to
-    // 'rotations' tab after the plan saves (line 292 in GamePlanner.tsx). If we click
-    // Lineup too soon we race that state update and get switched back.
-    await page.waitForTimeout(UI_TIMING.DATA_OPERATION * 2);
-  }
-
-  // Switch to Lineup tab and confirm it is actually selected before looking for slots
-  await page.getByRole('tab', { name: /Lineup/i }).click();
-  await expect(page.getByRole('tab', { name: /Lineup/i })).toHaveAttribute('aria-selected', 'true', { timeout: 5000 });
+  // Rotations is now the primary planning flow; Start details host the lineup editor.
+  await page.getByRole('tab', { name: /Rotations/i }).click();
+  await expect(page.getByRole('tab', { name: /Rotations/i })).toHaveAttribute('aria-selected', 'true', { timeout: 5000 });
+  await page.getByRole('tab', { name: 'Start' }).click();
   await page.waitForTimeout(UI_TIMING.NAVIGATION);
 
   // Wait for players to be loaded in the dropdown (ensure options exist)
-  const firstSlotSelect = page.locator('.position-slot select').first();
+  const firstSlotSelect = page.locator('.rotation-details-panel .position-slot select').first();
   await expect(firstSlotSelect).toBeVisible({ timeout: 10000 });
 
   // Check for pre-assigned players
@@ -251,7 +231,7 @@ async function setupLineup(page: Page) {
   }).toPass();
 
   // Assign the first 5 available players dynamically
-  const positionSlots = page.locator('.position-slot');
+  const positionSlots = page.locator('.rotation-details-panel .position-slot');
   const slotCount = await positionSlots.count();
   
   for (let i = 0; i < Math.min(slotCount, 5); i++) {
@@ -387,7 +367,7 @@ async function checkPlayerAvailability(page: Page) {
 async function createRotationPlan(page: Page) {
   console.log('Creating rotation plan...');
 
-  // Navigate to Rotations tab — previous steps (setupLineup / openGamePlanner) leave us on Lineup tab
+  // Navigate to Rotations tab where schedule and timeline controls live
   await page.getByRole('tab', { name: /Rotations/i }).click();
   await page.waitForTimeout(UI_TIMING.NAVIGATION);
 
@@ -430,8 +410,8 @@ async function verifyTimeline(page: Page) {
   const rotationCount = await rotationButtons.count();
   console.log(`  Found ${rotationCount} rotation pills`);
   
-  // Check that Lineup tab exists
-  await expect(page.getByRole('tab', { name: 'Lineup' })).toBeVisible();
+  // Ensure Start is always present and selected by default when timeline is visible.
+  await expect(page.getByRole('tab', { name: 'Start' })).toBeVisible();
   
   // Check that HT (halftime) marker exists (with longer timeout for observeQuery to update)
   try {
@@ -443,11 +423,32 @@ async function verifyTimeline(page: Page) {
   console.log('✓ Timeline structure verified');
 }
 
+async function verifyPrePlanSelectablePills(page: Page) {
+  console.log('Verifying pre-plan selectable pills and mounted details...');
+
+  await page.getByRole('tab', { name: /Rotations/i }).click();
+  await page.waitForTimeout(UI_TIMING.NAVIGATION);
+
+  const startPill = page.getByRole('tab', { name: 'Start' });
+  const rotationPills = page.locator('.planner-timeline-pill').filter({ hasText: /^R\d+$/ });
+  const firstRotationPill = rotationPills.first();
+
+  await expect(startPill).toBeVisible();
+  await expect(startPill).toHaveAttribute('aria-selected', 'true');
+  await expect(firstRotationPill).toBeVisible();
+
+  await firstRotationPill.click();
+  await expect(page.locator('.rotation-details-panel')).toBeVisible();
+  await expect(page.locator('.rotation-details-panel .panel-header h4')).toContainText(/Rotation\s+\d+/);
+
+  console.log('✓ Pre-plan numbered pills are selectable with mounted details');
+}
+
 async function planSubstitutions(page: Page) {
   console.log('Planning substitutions...');
   
   // Check if rotation pills exist (non-halftime)
-  const rotationPills = page.locator('.planner-timeline-pill:not(.planner-timeline-pill--halftime)');
+  const rotationPills = page.locator('.planner-timeline-pill').filter({ hasText: /^R\d+$/ });
   const buttonCount = await rotationPills.count();
   console.log(`  Found ${buttonCount} rotation pills`);
   
@@ -491,9 +492,12 @@ async function planSubstitutions(page: Page) {
     }
   }
   
-  // Note: Halftime lineup changes are made via the Lineup tab (halftime detail panel is read-only).
-  // The upstream/downstream recalculation handles auto-generating reverse swaps.
-  console.log('  (Halftime subs are managed via Lineup tab, not rotation detail panel)');
+  // Halftime lineup changes now happen directly in the HT details panel.
+  const halftimePill = page.locator('.planner-timeline-pill--halftime').first();
+  if (await halftimePill.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await halftimePill.click();
+    await expect(page.getByRole('heading', { name: 'Halftime Lineup' })).toBeVisible();
+  }
 
   // The rotation detail panel is still open from the first rotation swap above.
   // Wait for the lineup to update (observeQuery propagation after the swap).
@@ -576,7 +580,7 @@ async function testCopyFromPrevious(page: Page) {
   }
   
   // Click on second rotation (with force to bypass any remaining overlay)
-  const rotationButtons = page.locator('.rotation-button').filter({ hasText: /subs/ });
+  const rotationButtons = page.locator('.planner-timeline-pill').filter({ hasText: /^R\d+$/ });
   const secondRotation = rotationButtons.nth(1);
   
   if (await secondRotation.isVisible()) {
@@ -605,7 +609,7 @@ async function managePreGameCoachingNotes(page: Page) {
   await expect(page.getByRole('dialog')).toBeVisible();
 
   await page.fill('#pre-game-note-text', 'Pre-game: keep compact shape when out of possession');
-  await page.getByRole('button', { name: 'Create' }).click();
+  await page.getByRole('button', { name: 'Create', exact: true }).click();
 
   await expect(page.getByText('Pre-game: keep compact shape when out of possession')).toBeVisible();
 
@@ -692,34 +696,39 @@ test.describe('Game Planner with Timeline', () => {
     console.log('Step 10: Check Player Availability');
     await checkPlayerAvailability(page);
     console.log('');
+
+    // Step 11: Verify pre-plan timeline behavior
+    console.log('Step 11: Verify Pre-Plan Timeline');
+    await verifyPrePlanSelectablePills(page);
+    console.log('');
     
-    // Step 11: Create Rotation Plan
-    console.log('Step 11: Create Rotation Plan');
+    // Step 12: Create Rotation Plan
+    console.log('Step 12: Create Rotation Plan');
     await createRotationPlan(page);
     console.log('');
     
-    // Step 12: Verify Timeline
-    console.log('Step 12: Verify Timeline');
+    // Step 13: Verify Timeline
+    console.log('Step 13: Verify Timeline');
     await verifyTimeline(page);
     console.log('');
     
-    // Step 13: Plan Substitutions
-    console.log('Step 13: Plan Substitutions');
+    // Step 14: Plan Substitutions
+    console.log('Step 14: Plan Substitutions');
     await planSubstitutions(page);
     console.log('');
     
-    // Step 14: Verify Substitution Display
-    console.log('Step 14: Verify Substitution Display');
+    // Step 15: Verify Substitution Display
+    console.log('Step 15: Verify Substitution Display');
     await verifySubstitutionDisplay(page);
     console.log('');
     
-    // Step 15: Test Copy from Previous
-    console.log('Step 15: Test Copy from Previous');
+    // Step 16: Test Copy from Previous
+    console.log('Step 16: Test Copy from Previous');
     await testCopyFromPrevious(page);
     console.log('');
     
-    // Step 16: Verify Play Time Report
-    console.log('Step 16: Verify Play Time Report');
+    // Step 17: Verify Play Time Report
+    console.log('Step 17: Verify Play Time Report');
     await verifyPlayTimeReport(page);
     console.log('');
     

--- a/src/App.css
+++ b/src/App.css
@@ -5534,6 +5534,10 @@
   background: var(--primary-green);
   color: white;
 }
+.planner-timeline-pill:focus-visible {
+  outline: 3px solid rgba(26, 71, 42, 0.35);
+  outline-offset: 2px;
+}
 .planner-timeline-pill--halftime {
   border-color: #ff9800;
 }
@@ -5756,6 +5760,11 @@
   color: var(--text-secondary);
   font-size: 0.95rem;
   font-style: italic;
+}
+.planner-empty-hint {
+  margin: 0 0 0.75rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
 }
 
 

--- a/src/components/GamePlanner.interaction.test.tsx
+++ b/src/components/GamePlanner.interaction.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 const {
@@ -12,6 +12,8 @@ const {
   mockGamePlan,
   mockRotations,
   mockAmplifyQueryResult,
+  setMockGamePlans,
+  setMockRotations,
 } = vi.hoisted(() => ({
   mockSetDebugContext: vi.fn(),
   mockSetHelpContext: vi.fn(),
@@ -69,29 +71,99 @@ const {
     data: [],
     isSynced: true,
   },
+  setMockGamePlans: (() => {
+    const subscribers = new Set<(result: { items: unknown[]; isSynced?: boolean }) => void>();
+    let items = [] as unknown[];
+
+    const cloneItems = (nextItems: unknown[]) => nextItems.map((item) => ({ ...(item as Record<string, unknown>) }));
+    const emit = () => {
+      const snapshot = cloneItems(items);
+      subscribers.forEach((next) => next({ items: snapshot, isSynced: true }));
+    };
+
+    const setter = (nextItems: unknown[]) => {
+      items = cloneItems(nextItems);
+    };
+
+    Object.assign(setter, {
+      emit,
+      subscribe: (next: (result: { items: unknown[]; isSynced?: boolean }) => void) => {
+        subscribers.add(next);
+        next({ items: cloneItems(items), isSynced: true });
+        return () => subscribers.delete(next);
+      },
+      reset: () => {
+        subscribers.clear();
+        items = [];
+      },
+    });
+
+    return setter;
+  })(),
+  setMockRotations: (() => {
+    const subscribers = new Set<(result: { items: unknown[]; isSynced?: boolean }) => void>();
+    let items = [] as unknown[];
+
+    const cloneItems = (nextItems: unknown[]) => nextItems.map((item) => ({ ...(item as Record<string, unknown>) }));
+    const emit = () => {
+      const snapshot = cloneItems(items);
+      subscribers.forEach((next) => next({ items: snapshot, isSynced: true }));
+    };
+
+    const setter = (nextItems: unknown[]) => {
+      items = cloneItems(nextItems);
+    };
+
+    Object.assign(setter, {
+      emit,
+      subscribe: (next: (result: { items: unknown[]; isSynced?: boolean }) => void) => {
+        subscribers.add(next);
+        next({ items: cloneItems(items), isSynced: true });
+        return () => subscribers.delete(next);
+      },
+      reset: () => {
+        subscribers.clear();
+        items = [];
+      },
+    });
+
+    return setter;
+  })(),
 }));
 
-function createObserveQueryResult<T>(items: T[]) {
-  return {
-    subscribe: ({ next }: { next: (result: { items: T[]; isSynced?: boolean }) => void }) => {
-      next({ items, isSynced: true });
-      return { unsubscribe: vi.fn() };
-    },
-  };
-}
+const emitGamePlans = (setMockGamePlans as typeof setMockGamePlans & { emit: () => void }).emit;
+const emitRotations = (setMockRotations as typeof setMockRotations & { emit: () => void }).emit;
+const subscribeToGamePlans = (setMockGamePlans as typeof setMockGamePlans & {
+  subscribe: (next: (result: { items: unknown[]; isSynced?: boolean }) => void) => () => void;
+}).subscribe;
+const subscribeToRotations = (setMockRotations as typeof setMockRotations & {
+  subscribe: (next: (result: { items: unknown[]; isSynced?: boolean }) => void) => () => void;
+}).subscribe;
+const resetSubscriptions = () => {
+  (setMockGamePlans as typeof setMockGamePlans & { reset: () => void }).reset();
+  (setMockRotations as typeof setMockRotations & { reset: () => void }).reset();
+};
 
 vi.mock('aws-amplify/data', () => ({
   generateClient: () => ({
     models: {
       GamePlan: {
-        observeQuery: vi.fn(() => createObserveQueryResult([mockGamePlan])),
+        observeQuery: vi.fn(() => ({
+          subscribe: ({ next }: { next: (result: { items: unknown[]; isSynced?: boolean }) => void }) => ({
+            unsubscribe: subscribeToGamePlans(next),
+          }),
+        })),
         list: vi.fn().mockResolvedValue({ data: [mockGamePlan] }),
         update: vi.fn().mockResolvedValue({ data: mockGamePlan }),
         create: vi.fn().mockResolvedValue({ data: mockGamePlan }),
         delete: vi.fn().mockResolvedValue({ data: {} }),
       },
       PlannedRotation: {
-        observeQuery: vi.fn(() => createObserveQueryResult(mockRotations)),
+        observeQuery: vi.fn(() => ({
+          subscribe: ({ next }: { next: (result: { items: unknown[]; isSynced?: boolean }) => void }) => ({
+            unsubscribe: subscribeToRotations(next),
+          }),
+        })),
         update: vi.fn().mockResolvedValue({ data: mockRotations[0] }),
         create: vi.fn().mockResolvedValue({ data: mockRotations[0] }),
         delete: vi.fn().mockResolvedValue({ data: {} }),
@@ -113,6 +185,22 @@ vi.mock('../hooks/useTeamData', () => ({
 
 vi.mock('../hooks/useAmplifyQuery', () => ({
   useAmplifyQuery: vi.fn(() => mockAmplifyQueryResult),
+}));
+
+vi.mock('../hooks/useTeamCoachProfiles', () => ({
+  useTeamCoachProfiles: vi.fn(() => ({
+    profileMap: new Map(),
+  })),
+}));
+
+vi.mock('../hooks/useOfflineMutations', () => ({
+  useOfflineMutations: vi.fn(() => ({
+    mutations: {
+      createGameNote: vi.fn(),
+      updateGameNote: vi.fn(),
+      deleteGameNote: vi.fn(),
+    },
+  })),
 }));
 
 vi.mock('../contexts/HelpFabContext', () => ({
@@ -167,13 +255,33 @@ vi.mock('../services/rotationPlannerService', () => ({
   copyGamePlan: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { GamePlanner } from './GamePlanner';
+import { GamePlanner, type RotationTimelineItem } from './GamePlanner';
+import { reconcileSelectionKey } from '../utils/gamePlannerTimeline';
 
-describe('GamePlanner Start pill interaction', () => {
+function renderGamePlanner() {
+  return render(
+    <GamePlanner
+      game={{ id: 'game-1', opponent: 'Rivals FC', halfLengthMinutes: 30 } as never}
+      team={{
+        id: 'team-1',
+        formationId: 'formation-1',
+        coaches: ['coach-1'],
+        halfLengthMinutes: 30,
+        maxPlayersOnField: 2,
+      } as never}
+      onBack={vi.fn()}
+    />,
+  );
+}
+
+describe('GamePlanner timeline interaction', () => {
   let originalScrollIntoView: typeof Element.prototype.scrollIntoView;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetSubscriptions();
+    setMockGamePlans([mockGamePlan]);
+    setMockRotations(mockRotations);
     originalScrollIntoView = Element.prototype.scrollIntoView;
     Element.prototype.scrollIntoView = vi.fn();
   });
@@ -182,41 +290,153 @@ describe('GamePlanner Start pill interaction', () => {
     Element.prototype.scrollIntoView = originalScrollIntoView;
   });
 
-  it('renders the Start pill, opens the Starting Lineup panel, and returns to the Lineup tab', async () => {
+  it('defaults to Start selected and renders lineup editor inline without a Lineup tab', async () => {
     const user = userEvent.setup();
 
-    render(
-      <GamePlanner
-        game={{ id: 'game-1', opponent: 'Rivals FC', halfLengthMinutes: 30 } as never}
-        team={{
-          id: 'team-1',
-          formationId: 'formation-1',
-          coaches: ['coach-1'],
-          halfLengthMinutes: 30,
-          maxPlayersOnField: 2,
-        } as never}
-        onBack={vi.fn()}
-      />,
-    );
+    renderGamePlanner();
 
     await waitFor(() => {
       expect(screen.getByRole('tab', { name: /Rotations/i })).toHaveAttribute('aria-selected', 'true');
     });
 
-    const startPill = await screen.findByRole('button', { name: 'Start' });
-    expect(startPill).toBeInTheDocument();
-
-    await user.click(startPill);
+    const startPill = await screen.findByRole('tab', { name: 'Start' });
+    expect(startPill).toHaveAttribute('aria-selected', 'true');
+    expect(screen.queryByRole('tab', { name: /Lineup/i })).not.toBeInTheDocument();
 
     expect(await screen.findByRole('heading', { name: 'Starting Lineup' })).toBeInTheDocument();
+    expect(screen.getByTestId('lineup-builder')).toBeInTheDocument();
 
-    const editButton = screen.getByRole('button', { name: 'Edit starting lineup in the Lineup tab' });
-    await user.click(editButton);
+    await user.click(startPill);
+    expect(startPill).toHaveAttribute('aria-selected', 'true');
+  });
 
-    await waitFor(() => {
-      expect(screen.getByRole('tab', { name: /Lineup/i })).toHaveAttribute('aria-selected', 'true');
+  it('moves selection with keyboard arrows and keeps focus on selected pill', async () => {
+    const user = userEvent.setup();
+
+    renderGamePlanner();
+
+    const startPill = await screen.findByRole('tab', { name: 'Start' });
+    startPill.focus();
+    await user.keyboard('{ArrowRight}');
+
+    const halftimePill = screen.getByRole('tab', { name: 'HT' });
+    expect(halftimePill).toHaveAttribute('aria-selected', 'true');
+    expect(document.activeElement).toBe(halftimePill);
+    expect(screen.getByRole('heading', { name: 'Halftime Lineup' })).toBeInTheDocument();
+
+    await user.keyboard('{ArrowRight}');
+    const rotationOnePill = screen.getByRole('tab', { name: /^R1/ });
+    expect(rotationOnePill).toHaveAttribute('aria-selected', 'true');
+    expect(document.activeElement).toBe(rotationOnePill);
+    expect(screen.getByRole('heading', { name: /Rotation 1/ })).toBeInTheDocument();
+
+    await user.keyboard('{Home}');
+    expect(startPill).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('mounts details for all selectable pre-plan pills, including numbered rotations', async () => {
+    const user = userEvent.setup();
+    setMockGamePlans([]);
+    setMockRotations([]);
+
+    renderGamePlanner();
+
+    const startPill = await screen.findByRole('tab', { name: 'Start' });
+    const rotationOnePill = await screen.findByRole('tab', { name: 'R1' });
+    const halftimePill = await screen.findByRole('tab', { name: 'HT' });
+
+    expect(startPill).toHaveAttribute('aria-selected', 'true');
+    expect(await screen.findByRole('heading', { name: 'Starting Lineup' })).toBeInTheDocument();
+
+    await user.click(rotationOnePill);
+    expect(rotationOnePill).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('heading', { name: /Rotation 1/ })).toBeInTheDocument();
+    expect(screen.getByRole('tabpanel')).toBeInTheDocument();
+
+    await user.click(halftimePill);
+
+    expect(halftimePill).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('heading', { name: 'Halftime Lineup' })).toBeInTheDocument();
+    expect(screen.getByRole('tabpanel')).toBeInTheDocument();
+  });
+
+  it('preserves halftime selection when the timeline transitions from pre-plan to persisted items', async () => {
+    const user = userEvent.setup();
+    setMockGamePlans([]);
+    setMockRotations([]);
+
+    renderGamePlanner();
+
+    const halftimePill = await screen.findByRole('tab', { name: 'HT' });
+    await user.click(halftimePill);
+    expect(screen.getByRole('heading', { name: 'Halftime Lineup' })).toBeInTheDocument();
+
+    await act(async () => {
+      setMockGamePlans([mockGamePlan]);
+      setMockRotations(mockRotations);
+      emitGamePlans();
+      emitRotations();
     });
 
-    expect(screen.getByRole('heading', { name: 'First Half Starting Lineup' })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'HT' })).toHaveAttribute('aria-selected', 'true');
+    });
+    expect(screen.getByRole('heading', { name: 'Halftime Lineup' })).toBeInTheDocument();
+    expect(screen.getByRole('tabpanel')).toBeInTheDocument();
+  });
+
+  it('reconciles selection by rotation-number semantic identity when persisted keys change', () => {
+    const persistedTimeline: RotationTimelineItem[] = [
+      {
+        key: 'starting',
+        label: 'Start',
+        selection: 'starting',
+        substitutionsCount: 0,
+        variant: 'starting',
+      },
+      {
+        key: 'rotation-1-rotation-1-reloaded',
+        label: 'R1',
+        selection: 1,
+        substitutionsCount: 1,
+        variant: 'rotation',
+      },
+      {
+        key: 'halftime-rotation-3',
+        label: 'HT',
+        selection: 'halftime',
+        substitutionsCount: 0,
+        variant: 'halftime',
+      },
+    ];
+
+    expect(reconcileSelectionKey(persistedTimeline, 'rotation-1-10-synthetic')).toBe('rotation-1-rotation-1-reloaded');
+    expect(reconcileSelectionKey(persistedTimeline, 'rotation-1')).toBe('rotation-1-rotation-1-reloaded');
+
+    const syntheticTimeline: RotationTimelineItem[] = [
+      {
+        key: 'starting',
+        label: 'Start',
+        selection: 'starting',
+        substitutionsCount: 0,
+        variant: 'starting',
+      },
+      {
+        key: 'rotation-1-10-synthetic',
+        label: 'R1',
+        selection: 1,
+        substitutionsCount: 0,
+        variant: 'rotation',
+      },
+      {
+        key: 'halftime-2-20',
+        label: 'HT',
+        selection: 'halftime',
+        substitutionsCount: 0,
+        variant: 'halftime',
+      },
+    ];
+
+    expect(reconcileSelectionKey(syntheticTimeline, 'rotation-1-rotation-1-reloaded')).toBe('rotation-1-10-synthetic');
   });
 });

--- a/src/components/GamePlanner.tsx
+++ b/src/components/GamePlanner.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useMemo, useCallback } from "react";
+import { useEffect, useState, useRef, useMemo, useCallback, type KeyboardEvent } from "react";
 import { generateClient } from "aws-amplify/data";
 import type { Schema } from "../../amplify/data/resource";
 import type {
@@ -43,14 +43,15 @@ interface GamePlannerProps {
   onBack: () => void;
 }
 
-type RotationSelection = number | 'starting' | 'halftime';
+export type RotationSelection = number | 'starting' | 'halftime';
 
-interface RotationTimelineItem {
+export interface RotationTimelineItem {
   key: string;
   label: string;
   selection: RotationSelection;
   substitutionsCount: number;
   rotation?: PlannedRotation;
+  gameMinute?: number;
   variant: 'starting' | 'rotation' | 'halftime';
 }
 
@@ -116,11 +117,29 @@ function getRotationSubstitutionsCount(rotation: Pick<PlannedRotation, 'plannedS
   return parsePlannedSubstitutions(rotation.plannedSubstitutions).length;
 }
 
+function getRotationsPerHalf(halfLengthMinutes: number, intervalMinutes: number): number {
+  return Math.max(0, Math.floor(halfLengthMinutes / intervalMinutes) - 1);
+}
+
+function getRotationMinute(
+  rotationNumber: number,
+  rotationsPerHalf: number,
+  halfLengthMinutes: number,
+  rotationIntervalMinutes: number,
+): number {
+  if (rotationNumber <= rotationsPerHalf) {
+    return rotationNumber * rotationIntervalMinutes;
+  }
+
+  const secondHalfIndex = rotationNumber - rotationsPerHalf - 1;
+  return halfLengthMinutes + (secondHalfIndex * rotationIntervalMinutes);
+}
+
 function buildRotationTimelineItems(
   rotations: PlannedRotation[],
   halftimeRotationNumber?: number,
 ): RotationTimelineItem[] {
-  return [
+  const items: RotationTimelineItem[] = [
     {
       key: 'starting',
       label: 'Start',
@@ -128,40 +147,240 @@ function buildRotationTimelineItems(
       substitutionsCount: 0,
       variant: 'starting',
     },
-    ...rotations.map<RotationTimelineItem>((rotation) => {
-      const isHalftime = rotation.rotationNumber === halftimeRotationNumber;
-      const selection: RotationSelection = isHalftime ? 'halftime' : rotation.rotationNumber;
-      const variant: RotationTimelineItem['variant'] = isHalftime ? 'halftime' : 'rotation';
+  ];
 
-      return {
-        key: isHalftime ? `halftime-${rotation.id}` : `rotation-${rotation.id}`,
-        label: isHalftime ? 'HT' : `${rotation.gameMinute}'`,
-        selection,
+  if (rotations.length === 0) {
+    items.push({
+      key: 'halftime',
+      label: 'HT',
+      selection: 'halftime',
+      substitutionsCount: 0,
+      variant: 'halftime',
+    });
+    return items;
+  }
+
+  const seenHalftime = new Set<string>();
+  for (const rotation of rotations) {
+    const isHalftime = rotation.rotationNumber === halftimeRotationNumber;
+    if (isHalftime) {
+      const halftimeKey = rotation.id ? `halftime-${rotation.id}` : `halftime-${rotation.rotationNumber}-${rotation.gameMinute}`;
+      seenHalftime.add(halftimeKey);
+      items.push({
+        key: halftimeKey,
+        label: 'HT',
+        selection: 'halftime',
         substitutionsCount: getRotationSubstitutionsCount(rotation),
         rotation,
-        variant,
-      };
-    }),
+        variant: 'halftime',
+      });
+      continue;
+    }
+
+    items.push({
+      key: rotation.id
+        ? `rotation-${rotation.rotationNumber}-${rotation.id}`
+        : `rotation-${rotation.rotationNumber}-${rotation.gameMinute}`,
+      label: `R${rotation.rotationNumber}`,
+      selection: rotation.rotationNumber,
+      substitutionsCount: getRotationSubstitutionsCount(rotation),
+      rotation,
+      gameMinute: rotation.gameMinute,
+      variant: 'rotation',
+    });
+  }
+
+  if (!items.some((item) => item.selection === 'halftime')) {
+    items.splice(1, 0, {
+      key: 'halftime',
+      label: 'HT',
+      selection: 'halftime',
+      substitutionsCount: 0,
+      variant: 'halftime',
+    });
+  }
+
+  return items;
+}
+
+function buildPrePlanTimelineItems(
+  halfLengthMinutes: number,
+  rotationIntervalMinutes: number,
+): RotationTimelineItem[] {
+  const rotationsPerHalf = getRotationsPerHalf(halfLengthMinutes, rotationIntervalMinutes);
+  const halftimeRotationNumber = rotationsPerHalf > 0 ? rotationsPerHalf + 1 : 1;
+  const totalRotations = rotationsPerHalf * 2 + 1;
+
+  const items: RotationTimelineItem[] = [
+    {
+      key: 'starting',
+      label: 'Start',
+      selection: 'starting',
+      substitutionsCount: 0,
+      variant: 'starting',
+    },
   ];
+
+  for (let rotationNumber = 1; rotationNumber <= totalRotations; rotationNumber++) {
+    const gameMinute = getRotationMinute(
+      rotationNumber,
+      rotationsPerHalf,
+      halfLengthMinutes,
+      rotationIntervalMinutes,
+    );
+
+    if (rotationNumber === halftimeRotationNumber) {
+      items.push({
+        key: `halftime-${rotationNumber}-${gameMinute}`,
+        label: 'HT',
+        selection: 'halftime',
+        substitutionsCount: 0,
+        gameMinute,
+        variant: 'halftime',
+      });
+      continue;
+    }
+
+    items.push({
+      key: `rotation-${rotationNumber}-${gameMinute}-synthetic`,
+      label: `R${rotationNumber}`,
+      selection: rotationNumber,
+      substitutionsCount: 0,
+      gameMinute,
+      variant: 'rotation',
+    });
+  }
+
+  return items;
+}
+
+function getSelectionKey(item: RotationTimelineItem): string {
+  if (item.selection === 'starting') return 'starting';
+  if (item.selection === 'halftime') return 'halftime';
+  return `rotation-${item.selection}`;
+}
+
+function getSemanticSelectionKey(selectionKey: string): string | null {
+  if (selectionKey === 'starting') return 'starting';
+  if (selectionKey === 'halftime' || selectionKey.startsWith('halftime-')) return 'halftime';
+
+  const rotationMatch = /^rotation-(\d+)(?:-|$)/.exec(selectionKey);
+  if (rotationMatch) {
+    return `rotation-${rotationMatch[1]}`;
+  }
+
+  if (/^rotation-[^-]+$/.test(selectionKey)) {
+    return selectionKey;
+  }
+
+  return null;
+}
+
+function findTimelineItemBySemanticKey(
+  timelineItems: RotationTimelineItem[],
+  semanticSelectionKey: string,
+): RotationTimelineItem | undefined {
+  return timelineItems.find((item) => getSelectionKey(item) === semanticSelectionKey);
+}
+
+function reconcileSelectionKey(
+  timelineItems: RotationTimelineItem[],
+  currentSelectionKey: string,
+): string {
+  if (timelineItems.some((item) => item.key === currentSelectionKey)) {
+    return currentSelectionKey;
+  }
+
+  const semanticSelectionKey = getSemanticSelectionKey(currentSelectionKey);
+  if (semanticSelectionKey) {
+    const semanticMatch = findTimelineItemBySemanticKey(timelineItems, semanticSelectionKey);
+    if (semanticMatch) {
+      return semanticMatch.key;
+    }
+  }
+
+  const startItem = timelineItems.find((item) => item.selection === 'starting');
+  if (startItem) return startItem.key;
+
+  return timelineItems[0]?.key ?? 'starting';
+}
+
+function getTimelineTabId(itemKey: string): string {
+  return `planner-timeline-tab-${itemKey}`;
+}
+
+function getTimelinePanelId(): string {
+  return 'planner-rotation-details-panel';
+}
+
+function findTimelineItemByKey(
+  timelineItems: RotationTimelineItem[],
+  key: string,
+): RotationTimelineItem | undefined {
+  return timelineItems.find((item) => item.key === key);
+}
+
+function getNextTimelineIndex(index: number, delta: number, length: number): number {
+  if (length === 0) return 0;
+  const next = (index + delta + length) % length;
+  return next;
+}
+
+function getTimelineSelectionKey(selection: RotationSelection): string {
+  if (selection === 'starting') return 'starting';
+  if (selection === 'halftime') return 'halftime';
+  return `rotation-${selection}`;
+}
+
+function getTimelineItemBySelection(
+  timelineItems: RotationTimelineItem[],
+  selection: RotationSelection,
+): RotationTimelineItem | undefined {
+  return timelineItems.find((item) => getSelectionKey(item) === getTimelineSelectionKey(selection));
+}
+
+function getTimelineItemBySelectionKey(
+  timelineItems: RotationTimelineItem[],
+  selectionKey: string,
+): RotationTimelineItem | undefined {
+  const semanticSelectionKey = getSemanticSelectionKey(selectionKey);
+  if (semanticSelectionKey) {
+    return findTimelineItemBySemanticKey(timelineItems, semanticSelectionKey)
+      ?? timelineItems.find((item) => item.key === selectionKey);
+  }
+
+  return timelineItems.find((item) => item.key === selectionKey);
+}
+
+function getSelectedTimelineItem(
+  timelineItems: RotationTimelineItem[],
+  selectedTimelineKey: string,
+): RotationTimelineItem | undefined {
+  return findTimelineItemByKey(timelineItems, selectedTimelineKey)
+    ?? getTimelineItemBySelectionKey(timelineItems, selectedTimelineKey)
+    ?? timelineItems[0];
 }
 
 function resolveRotationSelection(
-  selectedRotation: RotationSelection | null,
-  halftimeRotationNumber?: number,
-): RotationSelection | null {
-  if (typeof selectedRotation === 'number' && selectedRotation === halftimeRotationNumber) {
-    return 'halftime';
-  }
-
-  return selectedRotation;
+  timelineItems: RotationTimelineItem[],
+  selectedTimelineKey: string,
+): RotationSelection {
+  return getSelectedTimelineItem(timelineItems, selectedTimelineKey)?.selection ?? 'starting';
 }
 
-function getBenchPlayersForLineup<TPlayer extends { id: string }>(
-  availablePlayers: TPlayer[],
-  lineup: Map<string, string>,
-): TPlayer[] {
-  const assignedPlayerIds = new Set(lineup.values());
-  return availablePlayers.filter((player) => !assignedPlayerIds.has(player.id));
+function getSelectedTimelineTabId(
+  timelineItems: RotationTimelineItem[],
+  selectedTimelineKey: string,
+): string | null {
+  const selected = getSelectedTimelineItem(timelineItems, selectedTimelineKey);
+  return selected ? getTimelineTabId(selected.key) : null;
+}
+
+function mapSelectionToTimelineKey(
+  timelineItems: RotationTimelineItem[],
+  selection: RotationSelection,
+): string | null {
+  return getTimelineItemBySelection(timelineItems, selection)?.key ?? null;
 }
 
 export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
@@ -248,12 +467,12 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
   const [halfLengthMinutes, setHalfLengthMinutes] = useState(
     game.halfLengthMinutes ?? teamDefaultHalfLength
   );
-  const [selectedRotation, setSelectedRotation] = useState<RotationSelection | null>(null);
+  const [selectedTimelineKey, setSelectedTimelineKey] = useState<string>('starting');
+  const [isPrePlanHalftimeDirty, setIsPrePlanHalftimeDirty] = useState(false);
   const [showCopyModal, setShowCopyModal] = useState(false);
   const [previousGames, setPreviousGames] = useState<Game[]>([]);
   const [isGenerating, setIsGenerating] = useState(false);
   const [planWarnings, setPlanWarnings] = useState<string[]>([]);
-  const [validationErrors, setValidationErrors] = useState<string[]>([]);
   const [isNoteModalOpen, setIsNoteModalOpen] = useState(false);
   const [editingNote, setEditingNote] = useState<GameNote | null>(null);
   const [swapModalData, setSwapModalData] = useState<{
@@ -263,10 +482,7 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
   } | null>(null);
   const timelineItemRefs = useRef(new Map<string, HTMLButtonElement>());
 
-  // New tab state for mobile redesign
-  const [plannerTab, setPlannerTab] = useState<'availability' | 'lineup' | 'rotations'>('lineup');
-  const tabInitialized = useRef(false);
-  const prevGamePlanId = useRef<string | null>(null);
+  const [plannerTab, setPlannerTab] = useState<'availability' | 'rotations'>('rotations');
 
   const maxPlayersOnField = team.maxPlayersOnField || 11;
   const preGameNotes = useMemo(
@@ -361,6 +577,7 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
         if (data.items.length > 0) {
           const plan = data.items[0];
           setGamePlan(plan);
+          setIsPrePlanHalftimeDirty(false);
           gamePlanIdRef.current = plan.id; // Update ref for use in other subscriptions
           setRotationIntervalMinutes(plan.rotationIntervalMinutes);
           setRotationsPerHalfInput(Math.max(0, Math.floor(halfLengthMinutes / plan.rotationIntervalMinutes) - 1));
@@ -388,6 +605,7 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
           gamePlanIdRef.current = null;
           setStartingLineup(new Map());
           setHalftimeLineup(null);
+          setIsPrePlanHalftimeDirty(false);
         }
       },
     });
@@ -460,23 +678,6 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
   };
 
 
-  // Initial tab selection (runs once when data first loads)
-  useEffect(() => {
-    if (tabInitialized.current) return;
-    if (gamePlan !== null || players.length > 0) {
-      setPlannerTab(gamePlan ? 'rotations' : 'lineup');
-      tabInitialized.current = true;
-    }
-  }, [gamePlan, players]);
-
-  // Auto-jump to rotations when plan is first created
-  useEffect(() => {
-    if (gamePlan?.id && prevGamePlanId.current === null) {
-      setPlannerTab('rotations');
-    }
-    prevGamePlanId.current = gamePlan?.id ?? null;
-  }, [gamePlan?.id]);
-
   const getPlayerAvailability = useCallback((playerId: string): string => {
     const availability = availabilities.find((a) => a.playerId === playerId);
     return availability?.status || "available";
@@ -501,15 +702,6 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
     () => normalizeRotationsForHelperCalls(rotations, 'Normalize rotation subs for helper calls'),
     [rotations],
   );
-
-  // Identify the halftime rotation number (first rotation of second half).
-  // Always derived from the plan settings — never from the half field on individual
-  // PlannedRotation records, which can be stale after a rotation-interval change.
-  const halftimeRotationNumber = useMemo(() => {
-    if (!gamePlan) return undefined;
-    const rotationsPerHalf = Math.max(0, Math.floor(halfLengthMinutes / rotationIntervalMinutes) - 1);
-    return rotationsPerHalf > 0 ? rotationsPerHalf + 1 : undefined;
-  }, [gamePlan, halfLengthMinutes, rotationIntervalMinutes]);
 
   const gamePlannerDebugContext = useMemo((): GamePlannerDebugContext => {
     const playerIdToNumber = new Map<string, number>(
@@ -577,28 +769,48 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
     return () => setHelpContext(null);
   }, [setHelpContext]);
 
-  const normalizedSelectedRotation = useMemo(
-    () => resolveRotationSelection(selectedRotation, halftimeRotationNumber),
-    [selectedRotation, halftimeRotationNumber],
-  );
+  const halftimeRotationNumber = useMemo(() => getRotationsPerHalf(halfLengthMinutes, rotationIntervalMinutes) + 1, [halfLengthMinutes, rotationIntervalMinutes]);
+  const isTimelineLoading = gamePlan !== null && rotations.length === 0;
 
-  const timelineItems = useMemo(
-    () => (gamePlan && rotations.length > 0
-      ? buildRotationTimelineItems(rotations, halftimeRotationNumber)
-      : []),
-    [gamePlan, rotations, halftimeRotationNumber],
-  );
+  const timelineItems = useMemo(() => {
+    if (isTimelineLoading) return [];
+    if (gamePlan) {
+      return buildRotationTimelineItems(rotations, halftimeRotationNumber);
+    }
 
-  const selectedTimelineKey = useMemo(
-    () => timelineItems.find((item) => item.selection === normalizedSelectedRotation)?.key ?? null,
-    [timelineItems, normalizedSelectedRotation],
+    return buildPrePlanTimelineItems(halfLengthMinutes, rotationIntervalMinutes);
+  }, [gamePlan, rotations, halftimeRotationNumber, isTimelineLoading, halfLengthMinutes, rotationIntervalMinutes]);
+
+  const resolvedSelectedTimelineKey = useMemo(
+    () => (timelineItems.length > 0 ? reconcileSelectionKey(timelineItems, selectedTimelineKey) : ''),
+    [timelineItems, selectedTimelineKey],
   );
 
   useEffect(() => {
-    if (!selectedTimelineKey) return undefined;
+    if (!resolvedSelectedTimelineKey || resolvedSelectedTimelineKey === selectedTimelineKey) return;
+    setSelectedTimelineKey(resolvedSelectedTimelineKey);
+  }, [resolvedSelectedTimelineKey, selectedTimelineKey]);
+
+  const normalizedSelectedRotation = useMemo(
+    () => resolveRotationSelection(timelineItems, resolvedSelectedTimelineKey),
+    [timelineItems, resolvedSelectedTimelineKey],
+  );
+
+  const selectedTimelineTabId = useMemo(
+    () => getSelectedTimelineTabId(timelineItems, resolvedSelectedTimelineKey),
+    [timelineItems, resolvedSelectedTimelineKey],
+  );
+
+  const selectedTimelineItem = useMemo(
+    () => getSelectedTimelineItem(timelineItems, resolvedSelectedTimelineKey),
+    [timelineItems, resolvedSelectedTimelineKey],
+  );
+
+  useEffect(() => {
+    if (!resolvedSelectedTimelineKey) return undefined;
 
     const timeoutId = window.setTimeout(() => {
-      const selectedElement = timelineItemRefs.current.get(selectedTimelineKey);
+      const selectedElement = timelineItemRefs.current.get(resolvedSelectedTimelineKey);
       if (!selectedElement) return;
 
       selectedElement.scrollIntoView({
@@ -609,7 +821,7 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
     }, UI_CONSTANTS.SCROLL.DELAY_MS);
 
     return () => window.clearTimeout(timeoutId);
-  }, [selectedTimelineKey]);
+  }, [resolvedSelectedTimelineKey]);
 
   // Memoize play time calculation which is expensive
   const playTimeData = useMemo(() => {
@@ -628,9 +840,25 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
 
   const halftimeLineupForDisplay = useMemo(() => {
     if (halftimeLineup !== null) return halftimeLineup;
-    if (!halftimeRotationNumber || rotations.length === 0) return startingLineup;
+    if (rotations.length === 0) return startingLineup;
     return computeLineupAtRotation(startingLineup, normalizedRotationsForHelpers, halftimeRotationNumber - 1);
   }, [halftimeLineup, halftimeRotationNumber, startingLineup, rotations.length, normalizedRotationsForHelpers]);
+
+  const handlePrePlanScheduleChangeWarning = useCallback(async () => {
+    if (gamePlan || !isPrePlanHalftimeDirty) return;
+
+    const shouldResetDraft = await confirm({
+      title: 'Halftime draft may be affected',
+      message: 'Schedule changes can invalidate your pre-plan halftime draft baseline. Keep is the default action.\n\nChoose Reset only if you want to rebuild halftime from the updated schedule baseline.',
+      confirmText: 'Reset Draft',
+      variant: 'warning',
+    });
+
+    if (shouldResetDraft) {
+      setHalftimeLineup(null);
+      setIsPrePlanHalftimeDirty(false);
+    }
+  }, [confirm, gamePlan, isPrePlanHalftimeDirty]);
 
   const handleLineupChange = async (positionId: string, playerId: string) => {
     const newLineup = new Map(startingLineup);
@@ -677,6 +905,9 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
   // so that both coupled inputs stay in sync with the new half length.
   const handleHalfLengthChange = async (newHalf: number) => {
     const clamped = Math.max(1, Math.min(newHalf, 99));
+    if (clamped !== halfLengthMinutes) {
+      await handlePrePlanScheduleChangeWarning();
+    }
     setHalfLengthMinutes(clamped);
     const newInterval = Math.max(1, Math.floor(clamped / (rotationsPerHalfInput + 1)));
     setRotationIntervalMinutes(newInterval);
@@ -689,6 +920,9 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
   };
 
   const handleResetHalfLength = async () => {
+    if (teamDefaultHalfLength !== halfLengthMinutes) {
+      await handlePrePlanScheduleChangeWarning();
+    }
     setHalfLengthMinutes(teamDefaultHalfLength);
     const newInterval = Math.max(1, Math.floor(teamDefaultHalfLength / (rotationsPerHalfInput + 1)));
     setRotationIntervalMinutes(newInterval);
@@ -702,16 +936,22 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
 
   // Coupled rotation input handlers
   // Single source of truth is rotationIntervalMinutes; rotationsPerHalf is always derived.
-  const handleRotationsChange = (rotations: number) => {
+  const handleRotationsChange = async (rotations: number) => {
     const maxRotations = Math.floor(halfLengthMinutes / 2);
     const clamped = Math.max(0, Math.min(rotations, maxRotations));
+    if (clamped !== rotationsPerHalfInput) {
+      await handlePrePlanScheduleChangeWarning();
+    }
     setRotationsPerHalfInput(clamped);
     const interval = Math.floor(halfLengthMinutes / (clamped + 1));
     setRotationIntervalMinutes(Math.max(1, interval));
   };
 
-  const handleIntervalChange = (interval: number) => {
+  const handleIntervalChange = async (interval: number) => {
     const clamped = Math.max(1, Math.min(interval, halfLengthMinutes));
+    if (clamped !== rotationIntervalMinutes) {
+      await handlePrePlanScheduleChangeWarning();
+    }
     setRotationIntervalMinutes(clamped);
     setRotationsPerHalfInput(Math.max(0, Math.floor(halfLengthMinutes / clamped) - 1));
   };
@@ -724,7 +964,6 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
     }
 
     setIsGenerating(true);
-    setValidationErrors([]);
     pendingLineupSaves.current++;
     pendingRotationSaves.current++;
 
@@ -1048,7 +1287,10 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
 
     setHalftimeLineup(newLineup);
 
-    if (!gamePlan || halftimeRotationNumber === undefined) return;
+    if (!gamePlan) {
+      setIsPrePlanHalftimeDirty(true);
+      return;
+    }
     const halftimeRotation = rotations.find(r => r.rotationNumber === halftimeRotationNumber);
     if (!halftimeRotation) return;
 
@@ -1076,10 +1318,61 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
     }
   };
 
-  const handleRotationClick = (rotationNumber: RotationSelection) => {
-    setSelectedRotation((currentSelection) => (
-      currentSelection === rotationNumber ? null : rotationNumber
-    ));
+  const handleRotationClick = (timelineKey: string) => {
+    const semanticSelectionKey = getSemanticSelectionKey(timelineKey);
+    setSelectedTimelineKey(semanticSelectionKey ?? timelineKey);
+  };
+
+  const handleTimelineKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    currentIndex: number,
+  ) => {
+    if (timelineItems.length === 0) return;
+
+    const focusTimelineIndex = (nextIndex: number) => {
+      const nextItem = timelineItems[nextIndex];
+      if (!nextItem) return;
+      setSelectedTimelineKey(getSelectionKey(nextItem));
+      window.setTimeout(() => {
+        timelineItemRefs.current.get(nextItem.key)?.focus();
+      }, 0);
+    };
+
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown': {
+        event.preventDefault();
+        focusTimelineIndex(getNextTimelineIndex(currentIndex, 1, timelineItems.length));
+        return;
+      }
+      case 'ArrowLeft':
+      case 'ArrowUp': {
+        event.preventDefault();
+        focusTimelineIndex(getNextTimelineIndex(currentIndex, -1, timelineItems.length));
+        return;
+      }
+      case 'Home': {
+        event.preventDefault();
+        focusTimelineIndex(0);
+        return;
+      }
+      case 'End': {
+        event.preventDefault();
+        focusTimelineIndex(Math.max(0, timelineItems.length - 1));
+        return;
+      }
+      case 'Enter':
+      case ' ': {
+        event.preventDefault();
+        const item = timelineItems[currentIndex];
+        if (item) {
+          setSelectedTimelineKey(getSelectionKey(item));
+        }
+        return;
+      }
+      default:
+        return;
+    }
   };
 
   /**
@@ -1247,8 +1540,11 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
       );
       // Data will update automatically via observeQuery subscriptions
 
-      // Select this rotation to edit it
-      setSelectedRotation(rotationNumber);
+      // Keep this rotation selected after reset.
+      const selectedKey = mapSelectionToTimelineKey(timelineItems, rotationNumber);
+      if (selectedKey) {
+        setSelectedTimelineKey(getSemanticSelectionKey(selectedKey) ?? selectedKey);
+      }
     } catch (error) {
       handleApiError(error, 'Failed to copy from previous rotation');
     } finally {
@@ -1347,62 +1643,23 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
   // Render selected rotation details — defined at component level so it can be
   // called from both renderRotationTimeline() and the bottom sheet.
   const renderSelectedDetails = () => {
-    if (normalizedSelectedRotation === null) return null;
-
     if (normalizedSelectedRotation === 'starting') {
-      const startingBenchPlayers = getBenchPlayersForLineup(startingLineupPlayers, startingLineup);
-
       return (
-        <div className="rotation-details-panel">
+        <div className="rotation-details-panel" id={getTimelinePanelId()} role="tabpanel" aria-labelledby={selectedTimelineTabId ?? undefined}>
           <div className="panel-header">
             <h4>Starting Lineup</h4>
-            <button
-              className="ht-edit-link"
-              onClick={() => setPlannerTab('lineup')}
-              aria-label="Edit starting lineup in the Lineup tab"
-            >
-              Edit in Lineup tab →
-            </button>
           </div>
-
-          <div className="rotation-lineup-custom">
-            <div className="position-lineup-grid">
-              {positions.map((position) => {
-                const assignedPlayerId = startingLineup.get(position.id);
-                const assignedPlayer = startingLineupPlayers.find((player) => player.id === assignedPlayerId);
-
-                return (
-                  <div key={position.id} className="position-slot">
-                    <div className="position-label">{position.abbreviation}</div>
-                    {assignedPlayer ? (
-                      <div className="assigned-player assigned-player--readonly">
-                        <span className="player-number">#{assignedPlayer.playerNumber || 0}</span>
-                        <span className="player-name-short">
-                          {assignedPlayer.firstName} {assignedPlayer.lastName}
-                        </span>
-                      </div>
-                    ) : (
-                      <div className="planner-readonly-empty-slot">Unassigned</div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-
-            <div className="bench-area">
-              <h4>Bench</h4>
-              <div className="bench-players">
-                {startingBenchPlayers.map((player) => (
-                  <div key={player.id} className="bench-player bench-player--readonly">
-                    <span className="player-number">#{player.playerNumber || 0}</span>
-                    <span className="player-name">
-                      {player.firstName} {player.lastName}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
+          {startingLineupPlayers.length === 0 ? (
+            <p className="planner-empty-hint">Mark players as available above to generate a rotation plan.</p>
+          ) : (
+            <LineupBuilder
+              positions={positions}
+              availablePlayers={startingLineupPlayers}
+              lineup={startingLineup}
+              onLineupChange={handleLineupChange}
+              showPreferredPositions={true}
+            />
+          )}
         </div>
       );
     }
@@ -1412,18 +1669,19 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
         ? rotations.find(r => r.rotationNumber === halftimeRotationNumber)
         : undefined;
 
-      const halftimeSubs = secondHalfStartRotation
+      const persistedHalftimeSubs = secondHalfStartRotation
         ? parsePlannedSubstitutions(secondHalfStartRotation.plannedSubstitutions, 'Parse halftime subs in renderSelectedDetails')
         : [];
+      const firstHalfFieldLineup = halftimeRotationNumber > 1 && rotations.length > 0
+        ? getLineupAtRotation(halftimeRotationNumber - 1)
+        : startingLineup;
+      const halftimeSubs = persistedHalftimeSubs.length > 0
+        ? persistedHalftimeSubs
+        : computeLineupDiff(firstHalfFieldLineup, halftimeLineupForDisplay);
       // Positions with an explicit halftime change (playerInId keyed by positionId).
       const halftimeSubsLineup = new Map<string, string>(
         halftimeSubs.map(s => [s.positionId, s.playerInId])
       );
-
-      // Players who are on the field at end of the first half (they "continue" unless subbed).
-      const firstHalfFieldLineup = halftimeRotationNumber && halftimeRotationNumber > 1
-        ? getLineupAtRotation(halftimeRotationNumber - 1)
-        : startingLineup;
       // Positions where the first-half player continues with no explicit sub.
       // Shown as a read-only list so the coach can see the full second-half lineup.
       const continuingEntries = Array.from(firstHalfFieldLineup.entries())
@@ -1435,20 +1693,25 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
         .filter(e => e.position && e.player);
 
       return (
-        <div className="rotation-details-panel">
+        <div className="rotation-details-panel" id={getTimelinePanelId()} role="tabpanel" aria-labelledby={selectedTimelineTabId ?? undefined}>
           <div className="panel-header">
-            <h4>Halftime</h4>
-            <button
-              className="ht-edit-link"
-              onClick={() => setPlannerTab('lineup')}
-              aria-label="Edit halftime lineup in the Lineup tab"
-            >
-              Edit in Lineup tab →
-            </button>
+            <h4>Halftime Lineup</h4>
           </div>
 
+          {halftimeLineup === null && (
+            <p className="planner-section-subtitle">Halftime lineup is using the current projected lineup. Edit to customize before saving.</p>
+          )}
+
+          <LineupBuilder
+            positions={positions}
+            availablePlayers={rotationPlayers}
+            lineup={halftimeLineupForDisplay}
+            onLineupChange={handleHalftimeLineupChange}
+            showPreferredPositions={true}
+          />
+
           {halftimeSubs.length === 0 ? (
-            <p className="ht-readonly-empty">No halftime changes — first half lineup continues.</p>
+            <p className="ht-readonly-empty">No halftime changes - first half lineup continues.</p>
           ) : (
             <>
               <div className="planned-subs-list">
@@ -1497,13 +1760,25 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
 
     // Rotation logic
     const rotation = rotations.find(r => r.rotationNumber === normalizedSelectedRotation);
-    if (!rotation) return null;
+    if (!rotation) {
+      return (
+        <div className="rotation-details-panel" id={getTimelinePanelId()} role="tabpanel" aria-labelledby={selectedTimelineTabId ?? undefined}>
+          <div className="panel-header">
+            <h4>
+              Rotation {normalizedSelectedRotation}
+              {typeof selectedTimelineItem?.gameMinute === 'number' ? ` (${selectedTimelineItem.gameMinute}')` : ''}
+            </h4>
+          </div>
+          <p className="planner-empty-hint">Create your game plan to edit substitutions for this rotation.</p>
+        </div>
+      );
+    }
 
     const subs = parsePlannedSubstitutions(rotation.plannedSubstitutions, 'Parse rotation subs in renderSelectedDetails');
     const currentLineup = getLineupAtRotation(rotation.rotationNumber);
 
     return (
-      <div className="rotation-details-panel">
+      <div className="rotation-details-panel" id={getTimelinePanelId()} role="tabpanel" aria-labelledby={selectedTimelineTabId ?? undefined}>
         <div className="panel-header">
           <h4>Rotation {rotation.rotationNumber} ({rotation.gameMinute}')</h4>
           <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
@@ -1632,36 +1907,18 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
     return (
       <div className="planner-section">
         {timelineItems.length > 0 && (
-          <div className="planner-timeline-strip">
-            {timelineItems.map((item) => {
-              const isSelected = normalizedSelectedRotation === item.selection;
-
-              if (item.variant === 'halftime') {
-                return (
-                  <button
-                    key={item.key}
-                    ref={(element) => {
-                      if (element) {
-                        timelineItemRefs.current.set(item.key, element);
-                        return;
-                      }
-
-                      timelineItemRefs.current.delete(item.key);
-                    }}
-                    className={`planner-timeline-pill planner-timeline-pill--halftime${isSelected ? ' planner-timeline-pill--active' : ''}`}
-                    onClick={() => handleRotationClick('halftime')}
-                  >
-                    {item.label}
-                    {item.substitutionsCount > 0 && (
-                      <span className="planner-sub-badge">{item.substitutionsCount}</span>
-                    )}
-                  </button>
-                );
-              }
+          <div className="planner-timeline-strip" role="tablist" aria-label="Rotation timeline">
+            {timelineItems.map((item, index) => {
+              const isSelected = resolvedSelectedTimelineKey === item.key;
 
               return (
                 <button
                   key={item.key}
+                  id={getTimelineTabId(item.key)}
+                  role="tab"
+                  aria-selected={isSelected}
+                  aria-controls={getTimelinePanelId()}
+                  tabIndex={isSelected ? 0 : -1}
                   ref={(element) => {
                     if (element) {
                       timelineItemRefs.current.set(item.key, element);
@@ -1670,8 +1927,9 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
 
                     timelineItemRefs.current.delete(item.key);
                   }}
-                  className={`planner-timeline-pill${isSelected ? ' planner-timeline-pill--active' : ''}`}
-                  onClick={() => handleRotationClick(item.selection)}
+                  className={`planner-timeline-pill${item.variant === 'halftime' ? ' planner-timeline-pill--halftime' : ''}${isSelected ? ' planner-timeline-pill--active' : ''}`}
+                  onClick={() => handleRotationClick(item.key)}
+                  onKeyDown={(event) => handleTimelineKeyDown(event, index)}
                 >
                   {item.label}
                   {item.substitutionsCount > 0 && (
@@ -1734,15 +1992,9 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
 
         {/* Tab Nav */}
         <nav className="planner-tab-nav" role="tablist">
-          {(['availability', 'lineup', 'rotations'] as const).map((tab) => {
-            const label = tab === 'availability' ? 'Availability' : tab === 'lineup' ? 'Lineup' : 'Rotations';
-            // Badge: lineup tab shows ✓ when all positions filled, rotations tab shows unfilled count
+          {(['availability', 'rotations'] as const).map((tab) => {
+            const label = tab === 'availability' ? 'Availability' : 'Rotations';
             let badge: string | null = null;
-            if (tab === 'lineup' && gamePlan) {
-              const firstHalfFull = startingLineup.size >= positions.length;
-              const secondHalfFull = rotations.length === 0 || halftimeLineupForDisplay.size >= positions.length;
-              if (firstHalfFull && secondHalfFull) badge = '✓';
-            }
             if (tab === 'rotations' && rotations.length > 0) {
               const unfilledCount = rotations.filter(r => {
                 return parsePlannedSubstitutions(r.plannedSubstitutions).length === 0;
@@ -1776,62 +2028,6 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
           </div>
         )}
 
-        {plannerTab === 'lineup' && (
-          <div className="planner-tab-panel">
-            {validationErrors.length > 0 && (
-              <div className="validation-errors">
-                <ul>{validationErrors.map((e, i) => <li key={i}>{e}</li>)}</ul>
-              </div>
-            )}
-            {gamePlan ? (
-              <>
-                <div className="planner-section">
-                  <div className="panel-header">
-                    <h4>First Half Starting Lineup</h4>
-                  </div>
-                  <LineupBuilder
-                    positions={positions}
-                    availablePlayers={startingLineupPlayers}
-                    lineup={startingLineup}
-                    onLineupChange={handleLineupChange}
-                    showPreferredPositions={true}
-                  />
-                </div>
-
-                {rotations.length > 0 && (
-                  <>
-                    <div className="lineup-halftime-divider">
-                      <span>Half Time</span>
-                    </div>
-                    <div className="planner-section planner-section--second-half">
-                      <div className="panel-header">
-                        <h4>Second Half Starting Lineup</h4>
-                      </div>
-                      <p className="planner-section-subtitle">
-                        Changes here update the Rotations tab automatically
-                      </p>
-                      <LineupBuilder
-                        positions={positions}
-                        availablePlayers={rotationPlayers}
-                        lineup={halftimeLineupForDisplay}
-                        onLineupChange={handleHalftimeLineupChange}
-                        showPreferredPositions={true}
-                      />
-                    </div>
-                  </>
-                )}
-              </>
-            ) : (
-              <div className="planner-empty-state">
-                <p>Set up your rotation schedule first.</p>
-                <button onClick={() => setPlannerTab('rotations')} className="btn-primary">
-                  Set up Rotations →
-                </button>
-              </div>
-            )}
-          </div>
-        )}
-
         {plannerTab === 'rotations' && (
           <div className="planner-tab-panel">
             {/* Rotation interval + create/update plan — always at the top */}
@@ -1844,7 +2040,7 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
                     <button
                       className="rotation-stepper-btn"
                       aria-label="Decrease half length"
-                      onClick={() => handleHalfLengthChange(halfLengthMinutes - 1)}
+                      onClick={() => { void handleHalfLengthChange(halfLengthMinutes - 1); }}
                     >−</button>
                     <input
                       type="number"
@@ -1854,16 +2050,16 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
                       min={1}
                       max={99}
                       value={halfLengthMinutes}
-                      onChange={(e) => handleHalfLengthChange(parseInt(e.target.value, 10) || 1)}
+                      onChange={(e) => { void handleHalfLengthChange(parseInt(e.target.value, 10) || 1); }}
                     />
                     <button
                       className="rotation-stepper-btn"
                       aria-label="Increase half length"
-                      onClick={() => handleHalfLengthChange(halfLengthMinutes + 1)}
+                      onClick={() => { void handleHalfLengthChange(halfLengthMinutes + 1); }}
                     >+</button>
                   </div>
                   {halfLengthMinutes !== teamDefaultHalfLength && (
-                    <button className="half-length-reset-btn" onClick={handleResetHalfLength}>
+                    <button className="half-length-reset-btn" onClick={() => { void handleResetHalfLength(); }}>
                       Reset to team default ({teamDefaultHalfLength} min)
                     </button>
                   )}
@@ -1877,7 +2073,7 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
                     <button
                       className="rotation-stepper-btn"
                       aria-label="Decrease rotations per half"
-                      onClick={() => handleRotationsChange(rotationsPerHalfInput - 1)}
+                      onClick={() => { void handleRotationsChange(rotationsPerHalfInput - 1); }}
                     >−</button>
                     <input
                       type="number"
@@ -1887,12 +2083,12 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
                       min={0}
                       max={Math.floor(halfLengthMinutes / 2)}
                       value={rotationsPerHalfInput}
-                      onChange={(e) => handleRotationsChange(parseInt(e.target.value, 10) || 0)}
+                      onChange={(e) => { void handleRotationsChange(parseInt(e.target.value, 10) || 0); }}
                     />
                     <button
                       className="rotation-stepper-btn"
                       aria-label="Increase rotations per half"
-                      onClick={() => handleRotationsChange(rotationsPerHalfInput + 1)}
+                      onClick={() => { void handleRotationsChange(rotationsPerHalfInput + 1); }}
                     >+</button>
                   </div>
                 </div>
@@ -1902,7 +2098,7 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
                     <button
                       className="rotation-stepper-btn"
                       aria-label="Decrease interval minutes"
-                      onClick={() => handleIntervalChange(rotationIntervalMinutes - 1)}
+                      onClick={() => { void handleIntervalChange(rotationIntervalMinutes - 1); }}
                     >−</button>
                     <input
                       type="number"
@@ -1912,12 +2108,12 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
                       min={1}
                       max={halfLengthMinutes}
                       value={rotationIntervalMinutes}
-                      onChange={(e) => handleIntervalChange(parseInt(e.target.value, 10) || 1)}
+                      onChange={(e) => { void handleIntervalChange(parseInt(e.target.value, 10) || 1); }}
                     />
                     <button
                       className="rotation-stepper-btn"
                       aria-label="Increase interval minutes"
-                      onClick={() => handleIntervalChange(rotationIntervalMinutes + 1)}
+                      onClick={() => { void handleIntervalChange(rotationIntervalMinutes + 1); }}
                     >+</button>
                   </div>
                 </div>
@@ -1949,17 +2145,18 @@ export function GamePlanner({ game, team, onBack }: GamePlannerProps) {
             )}
 
             {/* Timeline + selected detail + playtime */}
-            {gamePlan && rotations.length > 0 ? (
+            {isTimelineLoading ? (
+              <p className="planner-empty-hint">Loading timeline...</p>
+            ) : (
               <>
                 {renderRotationTimeline()}
+                {!gamePlan && (
+                  <p className="planner-empty-hint">Set your lineup and schedule, then create your plan.</p>
+                )}
                 {renderSelectedDetails()}
-                {renderPlayTime()}
+                {gamePlan && rotations.length > 0 && renderPlayTime()}
               </>
-            ) : gamePlan ? (
-              <div className="planner-empty-state">
-                <p>Click "Create Game Plan" above to generate rotations.</p>
-              </div>
-            ) : null}
+            )}
           </div>
         )}
 

--- a/src/utils/gamePlannerTimeline.ts
+++ b/src/utils/gamePlannerTimeline.ts
@@ -1,0 +1,215 @@
+import type { PlannedRotation } from "../types/schema";
+import type { PlannedSubstitution } from "../services/rotationPlannerService";
+
+export type RotationSelection = number | 'starting' | 'halftime';
+
+export interface RotationTimelineItem {
+  key: string;
+  label: string;
+  selection: RotationSelection;
+  substitutionsCount: number;
+  rotation?: PlannedRotation;
+  gameMinute?: number;
+  variant: 'starting' | 'rotation' | 'halftime';
+}
+
+function parsePlannedSubstitutions(
+  plannedSubstitutions: PlannedRotation['plannedSubstitutions'],
+): PlannedSubstitution[] {
+  try {
+    const parsed = JSON.parse((plannedSubstitutions as string) ?? '[]') as unknown;
+    return Array.isArray(parsed) ? parsed as PlannedSubstitution[] : [];
+  } catch {
+    return [];
+  }
+}
+
+function getRotationSubstitutionsCount(rotation: Pick<PlannedRotation, 'plannedSubstitutions'>): number {
+  return parsePlannedSubstitutions(rotation.plannedSubstitutions).length;
+}
+
+function getRotationsPerHalf(halfLengthMinutes: number, intervalMinutes: number): number {
+  return Math.max(0, Math.floor(halfLengthMinutes / intervalMinutes) - 1);
+}
+
+function getRotationMinute(
+  rotationNumber: number,
+  rotationsPerHalf: number,
+  halfLengthMinutes: number,
+  rotationIntervalMinutes: number,
+): number {
+  if (rotationNumber <= rotationsPerHalf) {
+    return rotationNumber * rotationIntervalMinutes;
+  }
+
+  const secondHalfIndex = rotationNumber - rotationsPerHalf - 1;
+  return halfLengthMinutes + (secondHalfIndex * rotationIntervalMinutes);
+}
+
+export function buildRotationTimelineItems(
+  rotations: PlannedRotation[],
+  halftimeRotationNumber?: number,
+): RotationTimelineItem[] {
+  const items: RotationTimelineItem[] = [
+    {
+      key: 'starting',
+      label: 'Start',
+      selection: 'starting',
+      substitutionsCount: 0,
+      variant: 'starting',
+    },
+  ];
+
+  if (rotations.length === 0) {
+    items.push({
+      key: 'halftime',
+      label: 'HT',
+      selection: 'halftime',
+      substitutionsCount: 0,
+      variant: 'halftime',
+    });
+    return items;
+  }
+
+  for (const rotation of rotations) {
+    const isHalftime = rotation.rotationNumber === halftimeRotationNumber;
+    if (isHalftime) {
+      const halftimeKey = rotation.id ? `halftime-${rotation.id}` : `halftime-${rotation.rotationNumber}-${rotation.gameMinute}`;
+      items.push({
+        key: halftimeKey,
+        label: 'HT',
+        selection: 'halftime',
+        substitutionsCount: getRotationSubstitutionsCount(rotation),
+        rotation,
+        variant: 'halftime',
+      });
+      continue;
+    }
+
+    items.push({
+      key: rotation.id
+        ? `rotation-${rotation.rotationNumber}-${rotation.id}`
+        : `rotation-${rotation.rotationNumber}-${rotation.gameMinute}`,
+      label: `R${rotation.rotationNumber}`,
+      selection: rotation.rotationNumber,
+      substitutionsCount: getRotationSubstitutionsCount(rotation),
+      rotation,
+      gameMinute: rotation.gameMinute,
+      variant: 'rotation',
+    });
+  }
+
+  if (!items.some((item) => item.selection === 'halftime')) {
+    items.splice(1, 0, {
+      key: 'halftime',
+      label: 'HT',
+      selection: 'halftime',
+      substitutionsCount: 0,
+      variant: 'halftime',
+    });
+  }
+
+  return items;
+}
+
+export function buildPrePlanTimelineItems(
+  halfLengthMinutes: number,
+  rotationIntervalMinutes: number,
+): RotationTimelineItem[] {
+  const rotationsPerHalf = getRotationsPerHalf(halfLengthMinutes, rotationIntervalMinutes);
+  const halftimeRotationNumber = rotationsPerHalf > 0 ? rotationsPerHalf + 1 : 1;
+  const totalRotations = rotationsPerHalf * 2 + 1;
+
+  const items: RotationTimelineItem[] = [
+    {
+      key: 'starting',
+      label: 'Start',
+      selection: 'starting',
+      substitutionsCount: 0,
+      variant: 'starting',
+    },
+  ];
+
+  for (let rotationNumber = 1; rotationNumber <= totalRotations; rotationNumber++) {
+    const gameMinute = getRotationMinute(
+      rotationNumber,
+      rotationsPerHalf,
+      halfLengthMinutes,
+      rotationIntervalMinutes,
+    );
+
+    if (rotationNumber === halftimeRotationNumber) {
+      items.push({
+        key: `halftime-${rotationNumber}-${gameMinute}`,
+        label: 'HT',
+        selection: 'halftime',
+        substitutionsCount: 0,
+        gameMinute,
+        variant: 'halftime',
+      });
+      continue;
+    }
+
+    items.push({
+      key: `rotation-${rotationNumber}-${gameMinute}-synthetic`,
+      label: `R${rotationNumber}`,
+      selection: rotationNumber,
+      substitutionsCount: 0,
+      gameMinute,
+      variant: 'rotation',
+    });
+  }
+
+  return items;
+}
+
+function getSelectionKey(item: RotationTimelineItem): string {
+  if (item.selection === 'starting') return 'starting';
+  if (item.selection === 'halftime') return 'halftime';
+  return `rotation-${item.selection}`;
+}
+
+function getSemanticSelectionKey(selectionKey: string): string | null {
+  if (selectionKey === 'starting') return 'starting';
+  if (selectionKey === 'halftime' || selectionKey.startsWith('halftime-')) return 'halftime';
+
+  const rotationMatch = /^rotation-(\d+)(?:-|$)/.exec(selectionKey);
+  if (rotationMatch) {
+    return `rotation-${rotationMatch[1]}`;
+  }
+
+  if (/^rotation-[^-]+$/.test(selectionKey)) {
+    return selectionKey;
+  }
+
+  return null;
+}
+
+function findTimelineItemBySemanticKey(
+  timelineItems: RotationTimelineItem[],
+  semanticSelectionKey: string,
+): RotationTimelineItem | undefined {
+  return timelineItems.find((item) => getSelectionKey(item) === semanticSelectionKey);
+}
+
+export function reconcileSelectionKey(
+  timelineItems: RotationTimelineItem[],
+  currentSelectionKey: string,
+): string {
+  if (timelineItems.some((item) => item.key === currentSelectionKey)) {
+    return currentSelectionKey;
+  }
+
+  const semanticSelectionKey = getSemanticSelectionKey(currentSelectionKey);
+  if (semanticSelectionKey) {
+    const semanticMatch = findTimelineItemBySemanticKey(timelineItems, semanticSelectionKey);
+    if (semanticMatch) {
+      return semanticMatch.key;
+    }
+  }
+
+  const startItem = timelineItems.find((item) => item.selection === 'starting');
+  if (startItem) return startItem.key;
+
+  return timelineItems[0]?.key ?? 'starting';
+}


### PR DESCRIPTION
- Remove lineup tab and anchor editing to Start/HT timeline pills

- Keep a details panel always visible with one selected pill

- Update planner interaction and E2E flows to the new timeline-first UX