### PR TITLE
fix: correct rotation plan CSV halftime labeling

### DIFF
--- a/src/components/GameManagement/PlanTab.test.tsx
+++ b/src/components/GameManagement/PlanTab.test.tsx
@@ -1386,7 +1386,90 @@ describe("PlanTab", () => {
       // Should have at least a Start column and a HT column
       const labels: string[] = callArgs.columns.map((c: { label: string }) => c.label);
       expect(labels[0]).toBe("Start");
-      expect(labels).toContain("HT");
+      expect(labels.some((label) => label.startsWith("HT "))).toBe(true);
+    });
+
+    it("omits halftime-boundary row from visible H2 columns and renumbers labels (issue #144)", () => {
+      const issueGame: Game = {
+        id: "game-144",
+        status: "scheduled",
+        halfLengthMinutes: 25,
+      } as Game;
+
+      const issueTeam: Team = {
+        ...mockTeam,
+        halfLengthMinutes: 25,
+      } as Team;
+
+      const issuePlannedRotations: PlannedRotation[] = [
+        {
+          id: "rot-1",
+          half: 1,
+          gameMinute: 8,
+          rotationNumber: 1,
+          plannedSubstitutions: "[]",
+        } as PlannedRotation,
+        {
+          id: "rot-2",
+          half: 1,
+          gameMinute: 16,
+          rotationNumber: 2,
+          plannedSubstitutions: "[]",
+        } as PlannedRotation,
+        {
+          id: "rot-3",
+          half: 2,
+          gameMinute: 25,
+          rotationNumber: 3,
+          plannedSubstitutions: "[]",
+        } as PlannedRotation,
+        {
+          id: "rot-4",
+          half: 2,
+          gameMinute: 33,
+          rotationNumber: 4,
+          plannedSubstitutions: "[]",
+        } as PlannedRotation,
+        {
+          id: "rot-5",
+          half: 2,
+          gameMinute: 41,
+          rotationNumber: 5,
+          plannedSubstitutions: "[]",
+        } as PlannedRotation,
+      ];
+
+      (useGamePlanner as any).mockReturnValue({
+        ...mockPlannerResult,
+        draft: {
+          ...mockPlannerResult.draft,
+          rotationIntervalMinutes: 8,
+        },
+      });
+
+      render(
+        <PlanTab
+          {...defaultProps}
+          game={issueGame}
+          gameState={issueGame}
+          team={issueTeam}
+          plannedRotations={issuePlannedRotations}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /export plan as csv/i }));
+      const callArgs = mockExportRotationPlanLocally.mock.calls[0][0];
+      const labels: string[] = callArgs.columns.map((c: { label: string }) => c.label);
+
+      expect(labels).toEqual([
+        "Start",
+        "R1 8′",
+        "R2 16′",
+        "HT 25′",
+        "R3 33′",
+        "R4 41′",
+      ]);
+      expect(labels).not.toContain("R5 41′");
     });
 
     it("is still visible in read-only mode when gamePlan exists", () => {

--- a/src/components/GameManagement/PlanTab.tsx
+++ b/src/components/GameManagement/PlanTab.tsx
@@ -836,12 +836,18 @@ export function PlanTab({
   const handleExportPlan = useCallback(() => {
     if (!gamePlan) return;
 
+    const exportHalfLength = Math.max(1, halfLengthInput || derivedHalfLength || 30);
+
     const h1Rotations = effectivePlannedRotations
       .filter((r) => r.half === 1)
       .sort((a, b) => (a.rotationNumber ?? 0) - (b.rotationNumber ?? 0));
     const h2Rotations = effectivePlannedRotations
       .filter((r) => r.half === 2)
       .sort((a, b) => (a.rotationNumber ?? 0) - (b.rotationNumber ?? 0));
+    const h2VisibleRotations = h2Rotations.filter((r) => {
+      if (typeof r.gameMinute !== "number") return true;
+      return r.gameMinute > exportHalfLength;
+    });
 
     const h1Rows = h1Rotations.map((r) => ({
       rotationNumber: r.rotationNumber ?? 0,
@@ -855,18 +861,19 @@ export function PlanTab({
     const columns: RotationPlanColumn[] = [];
     columns.push({ label: "Start", lineup: new Map(planner.draft.startingLineup) });
 
-    for (const rot of h1Rotations) {
+    for (const [index, rot] of h1Rotations.entries()) {
       const rotNum = rot.rotationNumber ?? 0;
       const lineup = computeLineupAtRotation(planner.draft.startingLineup, h1Rows, rotNum);
-      columns.push({ label: `R${rotNum} ${rot.gameMinute ?? "?"}′`, lineup });
+      columns.push({ label: `R${index + 1} ${rot.gameMinute ?? "?"}′`, lineup });
     }
 
-    columns.push({ label: "HT", lineup: new Map(effectiveHalftimeLineup) });
+    columns.push({ label: `HT ${exportHalfLength}′`, lineup: new Map(effectiveHalftimeLineup) });
 
-    for (const rot of h2Rotations) {
+    const h2LabelOffset = h1Rotations.length;
+    for (const [index, rot] of h2VisibleRotations.entries()) {
       const rotNum = rot.rotationNumber ?? 0;
       const lineup = computeLineupAtRotation(effectiveHalftimeLineup, h2Rows, rotNum);
-      columns.push({ label: `R${rotNum} ${rot.gameMinute ?? "?"}′`, lineup });
+      columns.push({ label: `R${h2LabelOffset + index + 1} ${rot.gameMinute ?? "?"}′`, lineup });
     }
 
     const playersById = new Map<string, string>();
@@ -899,6 +906,8 @@ export function PlanTab({
     positions,
     projectedPlayTimeRows,
     game.id,
+    halfLengthInput,
+    derivedHalfLength,
   ]);
 
   const requestTimelineSelection = useCallback((nextKey: string): boolean => {


### PR DESCRIPTION
Fix issue #144 by excluding halftime-boundary half-2 row from visible export columns, renumbering visible rotations sequentially, and labeling halftime as HT <halfLength>′.

Adds regression test covering the 25/33/41-minute second-half scenario to prevent extra R5 export column.